### PR TITLE
[objects] : add* methods now uses the cfg.remove_duplicates flag

### DIFF
--- a/objects/@exam/addSerie.m
+++ b/objects/@exam/addSerie.m
@@ -79,13 +79,24 @@ end
 
 for ex = 1 : numel(examArray)
     
-    % Allow duplicate ?
-    if examArray(ex).cfg.allow_duplicate % yes
-        % pass
-    else% no
+    % Remove duplicates
+    if examArray(ex).cfg.remove_duplicates
+        
         if examArray(ex).series.checkTag(tags)
-            continue
+            examArray(ex).series = examArray(ex).series.removeTag(tags);
         end
+        
+    else
+        
+        % Allow duplicate ?
+        if examArray(ex).cfg.allow_duplicate % yes
+            % pass
+        else% no
+            if examArray(ex).series.checkTag(tags)
+                continue
+            end
+        end
+        
     end
     
     % Fetch the directories
@@ -144,17 +155,7 @@ end % exam
 
 if nargout > 0
     
-    % Combine tags
-    allTags = '^(';
-    for t = 1:length(tags)
-        allTags = [allTags tags{t}]; %#ok<*AGROW>
-        if t~=length(tags)
-            allTags = [allTags '|'];
-        end
-    end
-    allTags = [allTags ')$'];
-    
-    varargout{1} = examArray.getSerie(allTags).toJob;
+    varargout{1} = examArray.getSerie( cellstr2regex(tags) ).toJob;
     
 end
 

--- a/objects/@mvObject/mvObject.m
+++ b/objects/@mvObject/mvObject.m
@@ -27,7 +27,8 @@ classdef mvObject < handle
                 mvObject_cfg = p.mvObject_cfg; % Save config in global workspace
             end
             
-            obj.cfg.allow_duplicate = mvObject_cfg.allow_duplicate;
+            obj.cfg.allow_duplicate   = mvObject_cfg.allow_duplicate;
+            obj.cfg.remove_duplicates = mvObject_cfg.remove_duplicates;
             
         end % ctor
         

--- a/objects/@mvObject/removeTag.m
+++ b/objects/@mvObject/removeTag.m
@@ -1,0 +1,17 @@
+function [ newArray ] = removeTag( mvArray, tag )
+%REMOVETAG removes all objects from the array according to the tag (regex)
+
+% Fetch all tags into a signle cellstr
+allTags = cellstr(char(mvArray.tag));
+
+% Concatenate if tag is a cellstr
+tags = cellstr2regex(tag);
+
+% Input tag exists in all tags of the array ?
+result = regexp(allTags,tags,'once');
+result = cellfun(@isempty,result);
+
+% Only accept (== keep) the non-matching tags
+newArray = mvArray(result);
+
+end % function

--- a/objects/@serie/addStim.m
+++ b/objects/@serie/addStim.m
@@ -45,13 +45,24 @@ end
 
 for ser = 1 : numel(serieArray)
     
-    % Allow duplicate ?
-    if serieArray(ser).cfg.allow_duplicate % yes
-        % pass
-    else% no
+    % Remove duplicates
+    if serieArray(ser).cfg.remove_duplicates
+        
         if serieArray(ser).stim.checkTag(tag)
-            continue
+            serieArray(ser).stim = serieArray(ser).stim.removeTag(tag);
         end
+        
+    else
+        
+        % Allow duplicate ?
+        if serieArray(ser).cfg.allow_duplicate % yes
+            % pass
+        else% no
+            if serieArray(ser).stim.checkTag(tag)
+                continue
+            end
+        end
+        
     end
     
     [exam_idx,serie_idx] = ind2sub(size(serieArray),ser);

--- a/objects/@serie/addVolume.m
+++ b/objects/@serie/addVolume.m
@@ -28,13 +28,24 @@ par.verbose = 0;
 
 for ser = 1 : numel(serieArray)
     
-    % Allow duplicate ?
-    if serieArray(ser).cfg.allow_duplicate % yes
-        % pass
-    else% no
+    % Remove duplicates
+    if serieArray(ser).cfg.remove_duplicates
+        
         if serieArray(ser).volumes.checkTag(tag)
-            continue
+            serieArray(ser).volumes = serieArray(ser).volumes.removeTag(tag);
         end
+        
+    else
+        
+        % Allow duplicate ?
+        if serieArray(ser).cfg.allow_duplicate % yes
+            % pass
+        else% no
+            if serieArray(ser).volumes.checkTag(tag)
+                continue
+            end
+        end
+        
     end
     
     try

--- a/objects/matvol_config.m
+++ b/objects/matvol_config.m
@@ -16,7 +16,7 @@ p.volume_show_viewer  = 'mrview';
 
 % --- @mvObject/mvObject (constructor) --------------------------------------------------------
 p.mvObject_cfg = struct;
-p.mvObject_cfg.allow_duplicate = 0;
-
+p.mvObject_cfg.allow_duplicate   = 0;
+p.mvObject_cfg.remove_duplicates = 1;
 
 end % function


### PR DESCRIPTION
This flag will alllow the methods to remove existing objects with the same tag, before adding it.
The option is, of course, defined in matvol_config.m