### PR TITLE
[ mvObject ] Features feb2018

### DIFF
--- a/SPM/firstlevel/job_first_level_specify.m
+++ b/SPM/firstlevel/job_first_level_specify.m
@@ -25,10 +25,6 @@ par.redo        = 0;
 
 par = complet_struct(par,defpar);
 
-if ~isfield(par,'TR')
-    error('par structure must have non empty TR field.')
-end
-
 
 %% SPM:Stats:fMRI model specification
 
@@ -40,16 +36,41 @@ end
 
 for subj = 1:nrSubject
     
-    if iscell(dirFonc{1})
-        subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg);
-        unzip_volume(subjectRuns);
-        subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg);
-        if par.rp
-            fileRP = get_subdir_regex_files(dirFonc{subj},'^rp.*txt');
+    % Check of all TR are the same for each run
+    if ~isfield(par,'TR')
+        
+        jsons = get_subdir_regex_files( dirFonc{subj} , '^dic.*json$' );
+        if iscell(dirFonc{1})
+            assert( length(dirFonc{subj}) == length(jsons) , 'dic.*json were no found in all volumes' )
+        else
+            assert( length(dirFonc) == length(jsons) , 'dic.*json were no found in all volumes' )
         end
-    else
-        subjectRuns = dirFonc;
+        [ TRs ] = get_string_from_json( jsons , 'RepetitionTime' , 'numeric' );
+        allTR = nan(size(TRs));
+        for idx = 1 : length(allTR)
+            allTR(idx) = TRs{idx}{1};
+        end
+        if iscell(dirFonc{1})
+            assert( all( allTR(1)==allTR ) , 'TR is not the same for each run : %s' , dirFonc{subj}{:} )
+        else
+            assert( all( allTR(1)==allTR ) , 'TR is not the same for each run : %s' , dirFonc{:} )
+        end
+        
+        % Define TR
+        par.TR = allTR(1)/1000; % convert milliseconds into seconds
+        
     end
+    
+    %     if iscell(dirFonc{1})
+    subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg,struct('verbose',0));
+    unzip_volume(subjectRuns);
+    subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg);
+    if par.rp
+        fileRP = get_subdir_regex_files(dirFonc{subj},'^rp.*txt');
+    end
+    %     else
+    %         subjectRuns = dirFonc;
+    %     end
     
     % When onsets are inside the .mat file
     if ~ isstruct(onsets{1})

--- a/SPM/firstlevel/job_first_level_specify.m
+++ b/SPM/firstlevel/job_first_level_specify.m
@@ -62,9 +62,9 @@ for subj = 1:nrSubject
     end
     
     %     if iscell(dirFonc{1})
-    subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg,struct('verbose',0));
-    unzip_volume(subjectRuns);
     subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg);
+    unzip_volume(subjectRuns);
+    subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg,struct('verbose',0));
     if par.rp
         fileRP = get_subdir_regex_files(dirFonc{subj},'^rp.*txt');
     end

--- a/SPM/preproc/do_topup_unwarp_4D.m
+++ b/SPM/preproc/do_topup_unwarp_4D.m
@@ -26,8 +26,10 @@ defpar.pct                = 0;
 
 par = complet_struct(par,defpar);
 
-parsge = par.sge;
-par.sge = -1; % only prepare commands
+if par.pct
+    parsge = par.sge;
+    par.sge = -1; % only prepare commands
+end
 
 
 %%  FSL:topup - FSL:unwarp
@@ -42,7 +44,7 @@ job = cell(0);
 
 for subj=1:nrSubject
     
-    job_subj = '';
+    job_subj = ''; % initialize
     
     % Extract subject name, and print it
     subjectName = get_parent_path(dirFonc{subj}(1));
@@ -54,8 +56,6 @@ for subj=1:nrSubject
     % Create inside the subject dir runName "topup" dire, which will be our
     % working directory
     topup_outdir = r_mkdir(subjectName,par.subdir);
-    
-    clear job_do_fsl_mean
     
     for run = 1:length(runList)
         
@@ -135,8 +135,9 @@ for subj=1:nrSubject
     
 end % for - subject
 
-
-par.sge = parsge;
+if par.pct
+    par.sge = parsge;
+end
 
 job = do_cmd_sge(job,par);
 

--- a/SPM/preproc/do_topup_unwarp_4D.m
+++ b/SPM/preproc/do_topup_unwarp_4D.m
@@ -124,7 +124,9 @@ for subj=1:nrSubject
         
         par.index=run;
         if par.do_apply(run)
-            job_subj = do_fsl_apply_topup(runList(run),fo,par, job_subj);
+            for volume_idx = 1:size(runList(run))
+                job_subj = do_fsl_apply_topup(runList{run}(volume_idx,:),fo,par, job_subj);
+            end
         end
         
     end

--- a/SPM/preproc/do_topup_unwarp_4D.m
+++ b/SPM/preproc/do_topup_unwarp_4D.m
@@ -1,4 +1,4 @@
-function do_topup_unwarp_4D(dirFonc,par)
+function job = do_topup_unwarp_4D(dirFonc,par)
 % DO_TOPUP_UNWARP_4D - FSL:topup - FSL:unwarp
 % img is multilevel directory (see get_subdir_regex).
 % The function will generate a mean for each runs (necessary to do topup on
@@ -16,15 +16,18 @@ end
 
 %% defpar
 
-defpar.todo              = 0;
-defpar.subdir            = 'topup';
-defpar.file_reg          = '^f.*nii';
-defpar.fsl_output_format = 'NIFTI';
-defpar.do_apply          = [];
-defpar.redo              = 0;
-defpar.pct               = 0;
+defpar.todo               = 0;
+defpar.subdir             = 'topup';
+defpar.file_reg           = '^f.*nii';
+defpar.fsl_output_format  = 'NIFTI';
+defpar.do_apply           = [];
+defpar.redo               = 0;
+defpar.pct                = 0;
 
 par = complet_struct(par,defpar);
+
+parsge = par.sge;
+par.sge = -1; % only prepare commands
 
 
 %%  FSL:topup - FSL:unwarp
@@ -35,109 +38,107 @@ else
     nrSubject = 1;
 end
 
-if par.pct % Parallel Computing Toolbox
+job = cell(0);
+
+for subj=1:nrSubject
     
-    parfor subj = 1 : nrSubject
-        routine_topup_unwarp_4D(dirFonc, par, subj)
-    end % for - subject
+    job_subj = '';
     
-else
+    % Extract subject name, and print it
+    subjectName = get_parent_path(dirFonc{subj}(1));
+    fprintf('[%s]: Preparing %s \n\n', mfilename, subjectName{1});
     
-    for subj = 1 : nrSubject
-        routine_topup_unwarp_4D(dirFonc, par, subj)
-    end % for - subject
+    % Fetch current subject images files
+    runList = get_subdir_regex_files(dirFonc{subj},par.file_reg);
     
-end
+    % Create inside the subject dir runName "topup" dire, which will be our
+    % working directory
+    topup_outdir = r_mkdir(subjectName,par.subdir);
+    
+    clear job_do_fsl_mean
+    
+    for run = 1:length(runList)
+        
+        % if realign & reslice runList is 'rf' volume whereas the mean is meanf
+        runName = runList{run}(1,:);
+        [pathstr, name, ext] = fileparts(runName);
+        if strcmp(name(1),'r')
+            runName = fullfile(pathstr,[name(2:end) ext]);
+        end
+        
+        % Generate if needed, a mean image for all runs (necessary for topup)
+        mean_files_cellstr = addprefixtofilenames({runName},'mean');
+        if ~exist(mean_files_cellstr{1},'file')
+            [ mean_files_cellstr{1}, job_subj ] = do_fsl_mean(runList(run),mean_files_cellstr{1},par, job_subj);
+        end
+        
+        % Is the orientation of all runs coherent ?
+        if run>1
+            if compare_orientation(fmean(1),runList(run)) == 0
+                warning('[%s]: WARNING reslicing mean image %s \n', mfilename, mean_files_cellstr{1});
+                [ resliced_mean, job_subj ]= do_fsl_reslice( mean_files_cellstr(1),fmean(1), job_subj);
+                mean_files_cellstr(1) = resliced_mean;
+            end
+        end
+        
+        runList{run}=char([cellstr(char(runList(run)));mean_files_cellstr]);
+        fmean(run) = mean_files_cellstr(1); %#ok<AGROW>
+        
+    end
+    
+    fout = addsuffixtofilenames(topup_outdir,'/4D_orig_topup_movpar.txt');
+    
+    if exist(fout{1},'file') && ~par.redo
+        fprintf('[%s]: skiping topup estimate because %s exists \n',mfilename,fout{1})
+    else
+        
+        %ACQP=topup_param_from_nifti_cenir(runList,topup_outdir)
+        try
+            ACQP=topup_param_from_json_cenir(fmean,topup_outdir);
+        catch err
+            warning(err.message)
+            ACQP=topup_param_from_nifti_cenir(fmean,topup_outdir);
+        end
+        if size(unique(ACQP),1)<2
+            error('all the serie have the same phase direction can not do topup')
+        end
+        
+        fo = addsuffixtofilenames(topup_outdir,'/4D_orig');
+        
+        par.checkorient=0; %give error if not same orient : don't want to check
+        
+        job_subj = do_fsl_merge(fmean,fo{1},par, job_subj);
+        job_subj = do_fsl_topup(fo,par, job_subj);
+        
+    end
+    
+    fo = addsuffixtofilenames(topup_outdir,'/4D_orig_topup');
+    
+    if isempty(par.do_apply)
+        par.do_apply = ones(size(runList));
+    end
+    
+    for run=1:length(runList)
+        %no because length is the same  realind = ceil(run/2); % because runList ad the mean
+        %par.index=realind;
+        
+        par.index=run;
+        if par.do_apply(run)
+            job_subj = do_fsl_apply_topup(runList(run),fo,par, job_subj);
+        end
+        
+    end
+    
+    job(end+1,1) = {char(job_subj)};
+    
+    disp(job{end})
+    
+end % for - subject
+
+
+par.sge = parsge;
+
+job = do_cmd_sge(job,par);
 
 
 end % function
-
-function routine_topup_unwarp_4D(dirFonc, par, subj)
-
-% Fetch current subject images files
-runList = get_subdir_regex_files(dirFonc{subj},par.file_reg);
-
-% Extract subject name, and print it
-subjectName = get_parent_path(dirFonc{subj}(1));
-fprintf('\n[%s]: currently working on %s \n', mfilename, subjectName{1})
-
-% Create inside the subject dir runName "topup" dire, which will be our
-% working directory
-topup_outdir = r_mkdir(subjectName,par.subdir);
-
-for run = 1:length(runList)
-    
-    % if realign & reslice runList is 'rf' volume whereas the mean is meanf
-    runName = runList{run}(1,:);
-    [pathstr, name, ext] = fileparts(runName);
-    if strcmp(name(1),'r')
-        runName = fullfile(pathstr,[name(2:end) ext]);
-    end
-    
-    % Generate if needed, a mean image for all runs (necessary for topup)
-    mean_files_cellstr = addprefixtofilenames({runName},'mean');
-    if ~exist(mean_files_cellstr{1},'file')
-        sgeset  = par.sge;
-        par.sge = 0;
-        mean_files_cellstr{1} = do_fsl_mean(runList(run),mean_files_cellstr{1},par);
-        par.sge = sgeset;
-    end
-    
-    % Is the orientation of all runs coherent ?
-    if run>1
-        if compare_orientation(fmean(1),mean_files_cellstr(1)) == 0
-            fprintf('[%s]: WARNING reslicing mean image %s \n', mfilename, mean_files_cellstr{1});
-            resliced_mean= do_fsl_reslice( mean_files_cellstr(1),fmean(1));
-            mean_files_cellstr(1) = resliced_mean;
-        end
-    end
-    
-    runList{run}=char([cellstr(char(runList(run)));mean_files_cellstr]);
-    fmean(run) = mean_files_cellstr(1); %#ok<AGROW>
-    
-end
-
-fout = addsuffixtofilenames(topup_outdir,'/4D_orig_topup_movpar.txt');
-
-if exist(fout{1},'file') && ~par.redo
-    fprintf('[%s]: skiping topup estimate because %s exists \n',mfilename,fout{1})
-else
-    
-    %ACQP=topup_param_from_nifti_cenir(runList,topup_outdir)
-    try
-        ACQP=topup_param_from_json_cenir(fmean,topup_outdir);
-    catch err
-        warning(err.message)
-        ACQP=topup_param_from_nifti_cenir(fmean,topup_outdir);
-    end
-    if size(unique(ACQP),1)<2
-        error('all the serie have the same phase direction can not do topup')
-    end
-    
-    fprintf('topup estimate %s \n',fout{1})
-    
-    fo = addsuffixtofilenames(topup_outdir,'/4D_orig');
-    par.checkorient=1; %give error if not same orient
-    do_fsl_merge(fmean,fo{1},par);
-    do_fsl_topup(fo,par);
-    
-end
-
-fo = addsuffixtofilenames(topup_outdir,'/4D_orig_topup');
-
-if isempty(par.do_apply)
-    par.do_apply = ones(size(runList));
-end
-
-for run=1:length(runList)
-    %no because length is the same  realind = ceil(run/2); % because runList ad the mean
-    %par.index=realind;
-    
-    par.index=run;
-    if par.do_apply(run)
-        do_fsl_apply_topup(runList(run),fo,par)
-    end
-    
-end
-
-end % function : routine_topup_unwarp_4D

--- a/SPM/preproc/do_topup_unwarp_4D.m
+++ b/SPM/preproc/do_topup_unwarp_4D.m
@@ -36,106 +36,108 @@ else
 end
 
 if par.pct % Parallel Computing Toolbox
-    nrUsableWorkers = Inf; 
+    
+    parfor subj = 1 : nrSubject
+        routine_topup_unwarp_4D(dirFonc, par, subj)
+    end % for - subject
+    
 else
-    nrUsableWorkers = 0;
+    
+    for subj = 1 : nrSubject
+        routine_topup_unwarp_4D(dirFonc, par, subj)
+    end % for - subject
+    
 end
-
-% just to solve a parfor problem : need to pre-allocate some internal variables
-fmean = cell(nrSubject,1);
-par_topup = cell(nrSubject,1);
-ACQP = cell(nrSubject,1);
-
-parfor(subj = 1 : nrSubject, nrUsableWorkers)
-% for subj = 1 : nrSubject % use this line (classic for loop) to debug, and comment the previous line (parfor loop)
-    
-    % Fetch current subject images files
-    runList = get_subdir_regex_files(dirFonc{subj},par.file_reg);
-    
-    % Extract subject name, and print it
-    subjectName = get_parent_path(dirFonc{subj}(1));
-    fprintf('\n[%s]: currently working on %s \n', mfilename, subjectName{1})
-    
-    % Create inside the subject dir runName "topup" dire, which will be our
-    % working directory
-    topup_outdir = r_mkdir(subjectName,par.subdir);
-    
-    for run = 1:length(runList)
-        
-        % if realign & reslice runList is 'rf' volume whereas the mean is meanf
-        runName = runList{run}(1,:);
-        [pathstr, name, ext] = fileparts(runName);
-        if strcmp(name(1),'r')
-            runName = fullfile(pathstr,[name(2:end) ext]);
-        end
-        
-        % Generate if needed, a mean image for all runs (necessary for topup)
-        mean_files_cellstr = addprefixtofilenames({runName},'mean');
-        if ~exist(mean_files_cellstr{1},'file')
-            par_save = par;
-            par_save.sge = 0;
-            mean_files_cellstr{1} = do_fsl_mean(runList(run),mean_files_cellstr{1},par_save);
-        end
-        
-        % Is the orientation of all runs coherent ?
-        if run>1
-            if compare_orientation(fmean{subj}(1),mean_files_cellstr(1)) == 0
-                fprintf('[%s]: WARNING reslicing mean image %s \n', mfilename, mean_files_cellstr{1});
-                resliced_mean= do_fsl_reslice( mean_files_cellstr(1),fmean{subj}(1));
-                mean_files_cellstr(1) = resliced_mean;
-            end
-        end
-        
-        runList{run}=char([cellstr(char(runList(run)));mean_files_cellstr]);
-        fmean{subj}(run) = mean_files_cellstr(1);
-        
-    end % runList
-    
-    fout = addsuffixtofilenames(topup_outdir,'/4D_orig_topup_movpar.txt');
-    
-    if exist(fout{1},'file') && ~par.redo
-        fprintf('[%s]: skiping topup estimate because %s exists \n',mfilename,fout{1})
-    else
-        
-        %ACQP=topup_param_from_nifti_cenir(runList,topup_outdir)
-        try
-            ACQP{subj}=topup_param_from_json_cenir(fmean{subj},topup_outdir);
-        catch err
-            warning(err.message)
-            ACQP{subj}=topup_param_from_nifti_cenir(fmean{subj},topup_outdir);
-        end
-        if size(unique(ACQP{subj}),1)<2
-            error('all the serie have the same phase direction can not do topup')
-        end
-        
-        fprintf('topup estimate %s \n',fout{1})
-        
-        fo = addsuffixtofilenames(topup_outdir,'/4D_orig');
-        par_topup{subj} = par;
-        par_topup{subj}.checkorient=1; %give error if not same orient
-        do_fsl_merge(fmean{subj},fo{1},par_topup{subj});
-        do_fsl_topup(fo,par_topup{subj});
-        
-    end
-    
-    fo = addsuffixtofilenames(topup_outdir,'/4D_orig_topup');
-    
-    if isempty(par.do_apply)
-        par_topup{subj}.do_apply = ones(size(runList));
-    end
-    
-    for run=1:length(runList)
-        %no because length is the same  realind = ceil(run/2); % because runList ad the mean
-        %par.index=realind;
-        
-        par_topup{subj}.index=run;
-        if par_topup{subj}.do_apply(run)
-            do_fsl_apply_topup(runList(run),fo,par_topup{subj})
-        end
-        
-    end % runList
-    
-end % for - subject
 
 
 end % function
+
+function routine_topup_unwarp_4D(dirFonc, par, subj)
+
+% Fetch current subject images files
+runList = get_subdir_regex_files(dirFonc{subj},par.file_reg);
+
+% Extract subject name, and print it
+subjectName = get_parent_path(dirFonc{subj}(1));
+fprintf('\n[%s]: currently working on %s \n', mfilename, subjectName{1})
+
+% Create inside the subject dir runName "topup" dire, which will be our
+% working directory
+topup_outdir = r_mkdir(subjectName,par.subdir);
+
+for run = 1:length(runList)
+    
+    % if realign & reslice runList is 'rf' volume whereas the mean is meanf
+    runName = runList{run}(1,:);
+    [pathstr, name, ext] = fileparts(runName);
+    if strcmp(name(1),'r')
+        runName = fullfile(pathstr,[name(2:end) ext]);
+    end
+    
+    % Generate if needed, a mean image for all runs (necessary for topup)
+    mean_files_cellstr = addprefixtofilenames({runName},'mean');
+    if ~exist(mean_files_cellstr{1},'file')
+        sgeset  = par.sge;
+        par.sge = 0;
+        mean_files_cellstr{1} = do_fsl_mean(runList(run),mean_files_cellstr{1},par);
+        par.sge = sgeset;
+    end
+    
+    % Is the orientation of all runs coherent ?
+    if run>1
+        if compare_orientation(fmean(1),mean_files_cellstr(1)) == 0
+            fprintf('[%s]: WARNING reslicing mean image %s \n', mfilename, mean_files_cellstr{1});
+            resliced_mean= do_fsl_reslice( mean_files_cellstr(1),fmean(1));
+            mean_files_cellstr(1) = resliced_mean;
+        end
+    end
+    
+    runList{run}=char([cellstr(char(runList(run)));mean_files_cellstr]);
+    fmean(run) = mean_files_cellstr(1); %#ok<AGROW>
+    
+end
+
+fout = addsuffixtofilenames(topup_outdir,'/4D_orig_topup_movpar.txt');
+
+if exist(fout{1},'file') && ~par.redo
+    fprintf('[%s]: skiping topup estimate because %s exists \n',mfilename,fout{1})
+else
+    
+    %ACQP=topup_param_from_nifti_cenir(runList,topup_outdir)
+    try
+        ACQP=topup_param_from_json_cenir(fmean,topup_outdir);
+    catch err
+        warning(err.message)
+        ACQP=topup_param_from_nifti_cenir(fmean,topup_outdir);
+    end
+    if size(unique(ACQP),1)<2
+        error('all the serie have the same phase direction can not do topup')
+    end
+    
+    fprintf('topup estimate %s \n',fout{1})
+    
+    fo = addsuffixtofilenames(topup_outdir,'/4D_orig');
+    par.checkorient=1; %give error if not same orient
+    do_fsl_merge(fmean,fo{1},par);
+    do_fsl_topup(fo,par);
+    
+end
+
+fo = addsuffixtofilenames(topup_outdir,'/4D_orig_topup');
+
+if isempty(par.do_apply)
+    par.do_apply = ones(size(runList));
+end
+
+for run=1:length(runList)
+    %no because length is the same  realind = ceil(run/2); % because runList ad the mean
+    %par.index=realind;
+    
+    par.index=run;
+    if par.do_apply(run)
+        do_fsl_apply_topup(runList(run),fo,par)
+    end
+    
+end
+
+end % function : routine_topup_unwarp_4D

--- a/Tools/nifti_hdr/compare_orientation.m
+++ b/Tools/nifti_hdr/compare_orientation.m
@@ -1,16 +1,16 @@
-function [res_boolean diff_vols diffmat] = compare_orientation(v1,v2)
+function [ res_boolean, diff_vols, diffmat ] = compare_orientation(v1,v2)
 
 diff_vols={};
 diffmat=[];
 
 for k=1:length(v1)
+    
     res_boolean(k)=1;
     
     vol1 = nifti_spm_vol(v1{k});
     vol2 = nifti_spm_vol(v2{k});
     
     vol1=vol1(1);vol2=vol2(1); % for 4 D volume juste take the first one
-    
     
     if any(vol2.dim - vol1.dim)
         fprintf('Dimemntion differ %s compare to %s \n',vol1.fname,vol2.fname)
@@ -28,3 +28,5 @@ for k=1:length(v1)
     end
     
 end
+
+end % function

--- a/Tools/sge_cmd/do_cmd_sge.m
+++ b/Tools/sge_cmd/do_cmd_sge.m
@@ -75,7 +75,7 @@ if par.sge == -1 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     return
 end
 
-if par.job_pack>1;
+if par.job_pack>1
     jnew={};
     for nn=1:par.job_pack:length(job)
         kkkend = nn+par.job_pack-1;
@@ -130,7 +130,7 @@ else % par.sge ~= 0 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
     job_dir = par.jobdir;
     
-    if ~exist(job_dir)
+    if ~exist(job_dir,'dir')
         mkdir(job_dir);
     end
     

--- a/Tools/sge_cmd/do_cmd_sge.m
+++ b/Tools/sge_cmd/do_cmd_sge.m
@@ -71,7 +71,7 @@ if ~isempty(jobappend)
     end
 end
 
-if par.sge == -1
+if par.sge == -1 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     return
 end
 

--- a/Tools/utils/get_string_from_json.m
+++ b/Tools/utils/get_string_from_json.m
@@ -12,24 +12,32 @@ function [ out ] = get_string_from_json( filename , field_to_get , field_type )
 % Made to replace loadjson form jsonlab
 
 %% Check inpur parameters
-if iscell(filename)
-    for kk=1:length(filename)
-        out(kk) = get_string_from_json( filename{kk} , field_to_get , field_type );
-    end
-    return    
-end
 
 assert(nargin==3,'Wrong number of input arguments : 3 required')
 
-assert(ischar(filename),'filename must be a char')
+assert(ischar(filename) || iscellstr(filename),'filename must be a char or cellstr')
 
-assert(iscell(field_to_get)&&isvector(field_to_get),'field_to_get cellvector')
-assert(iscell(field_type)&&isvector(field_type),'field_type cellvector')
+assert((iscellstr(field_to_get)||ischar(field_to_get))&&isvector(field_to_get),'field_to_get cellstr')
+assert((iscellstr(field_type  )||ischar(field_type  ))&&isvector(field_type  ),'field_type cellstr')
+
+field_to_get = cellstr(field_to_get);
+field_type   = cellstr(field_type);
 
 assert(numel(field_to_get)==numel(field_type),'field_to_get field_type must have the same dimension')
 
 assert(all(cellfun(@ischar,field_to_get)),'all elements in field_to_get must be char')
 assert(all(cellfun(@ischar,field_type)),'all elements in field_type must be char')
+
+
+%% Loop over all files
+
+if iscellstr(filename)
+    out = cell(length(filename),1);
+    for kk=1:length(filename)
+        out{kk} = get_string_from_json( filename{kk} , field_to_get , field_type );
+    end
+    return
+end
 
 
 %% Read the file

--- a/Wrappers/do_fsl_apply_topup.m
+++ b/Wrappers/do_fsl_apply_topup.m
@@ -13,6 +13,8 @@ defpar.submit_sleep =0;
 defpar.sge_queu = 'long';
 defpar.jobname = 'fsl_apply_topup';
 
+job = '';
+
 par = complet_struct(par,defpar);
 
 fin = cellstr(char(fin));
@@ -26,8 +28,6 @@ end
 if exist(fo{end},'file') && ~par.redo
     fprintf('[%s]: skiping topup write, because %s exist \n',mfilename,fo{end});
 else
-    
-    job = '';
     
     for k=1:length(fin)
         

--- a/Wrappers/do_fsl_apply_topup.m
+++ b/Wrappers/do_fsl_apply_topup.m
@@ -5,7 +5,7 @@ if ~exist('jobappend','var'), jobappend ='';end
 
 
 defpar.outprefix = 'ut';
-defpar.sge=1;
+defpar.sge=0;
 defpar.index=0;
 defpar.acqpfile = 'acqp.txt';
 defpar.fsl_output_format = 'NIFTI';

--- a/Wrappers/do_fsl_apply_topup.m
+++ b/Wrappers/do_fsl_apply_topup.m
@@ -1,7 +1,7 @@
 function [ job ] = do_fsl_apply_topup(fin,ftopup,par,jobappend)
 
-if ~exist('par'),par ='';end
-if ~exist('jobappend','var'), jobappend ='';end
+if ~exist('par'      ,'var'), par ='';       end
+if ~exist('jobappend','var'), jobappend =''; end
 
 defpar.outprefix = 'ut';
 defpar.sge=0;
@@ -12,8 +12,6 @@ defpar.redo=0;
 defpar.submit_sleep =0;
 defpar.sge_queu = 'long';
 defpar.jobname = 'fsl_apply_topup';
-
-job = '';
 
 par = complet_struct(par,defpar);
 
@@ -41,10 +39,10 @@ else
         
         cmd = sprintf('cd %s;\nexport FSLOUTPUTTYPE=%s;\napplytopup --imain=%s --datain=%s --method=jac --inindex=%d  --topup=%s --out=%s;\n',...
             dirtopup,par.fsl_output_format,fin{k},par.acqpfile,ii,fff,fo{k});
-        job = [job cmd];
+        
+        job{k} = cmd;
+        
     end
-    
-    job = {job};
     
     job = do_cmd_sge(job,par,jobappend);
     

--- a/Wrappers/do_fsl_apply_topup.m
+++ b/Wrappers/do_fsl_apply_topup.m
@@ -1,8 +1,7 @@
-function do_fsl_apply_topup(fin,ftopup,par,jobappend)
+function [ job ] = do_fsl_apply_topup(fin,ftopup,par,jobappend)
 
 if ~exist('par'),par ='';end
 if ~exist('jobappend','var'), jobappend ='';end
-
 
 defpar.outprefix = 'ut';
 defpar.sge=0;
@@ -28,8 +27,10 @@ if exist(fo{end},'file') && ~par.redo
     fprintf('[%s]: skiping topup write, because %s exist \n',mfilename,fo{end});
 else
     
-    for k=1:length(fin)
+    job = '';
     
+    for k=1:length(fin)
+        
         if length(par.index)>1
             ii = par.index(k);
         else
@@ -38,10 +39,15 @@ else
         
         [dirtopup fff] = fileparts(ftopup{k});
         
-        cmd = sprintf('cd %s;export FSLOUTPUTTYPE=%s; applytopup --imain=%s --datain=%s --method=jac --inindex=%d  --topup=%s --out=%s;\n',...
+        cmd = sprintf('cd %s;\nexport FSLOUTPUTTYPE=%s;\napplytopup --imain=%s --datain=%s --method=jac --inindex=%d  --topup=%s --out=%s;\n',...
             dirtopup,par.fsl_output_format,fin{k},par.acqpfile,ii,fff,fo{k});
-        job{k} = cmd;
+        job = [job cmd];
     end
     
+    job = {job};
+    
     job = do_cmd_sge(job,par,jobappend);
+    
 end
+
+end % function

--- a/Wrappers/do_fsl_mean.m
+++ b/Wrappers/do_fsl_mean.m
@@ -1,6 +1,8 @@
-function out = do_fsl_mean(fo,outname,par)
+function [ out, job ]= do_fsl_mean(fo,outname,par,jobappend)
 
 if ~exist('par'),par ='';end
+if ~exist('jobappend','var'), jobappend ='';end
+
 
 defpar.sge=0;
 defpar.fsl_output_format = 'NIFTI_GZ'; %ANALYZE, NIFTI, NIFTI_PAIR, NIFTI_GZ
@@ -31,11 +33,11 @@ outname = change_file_extension(outname,'');
 fo = cellstr(char(fo));
 
 [pp ffo]=get_parent_path(fo);
- 
-cmd = sprintf('export FSLOUTPUTTYPE=%s;cd %s;fslmaths %s -nan -thr 0',par.fsl_output_format,pp{1},fo{1});
+
+cmd = sprintf('export FSLOUTPUTTYPE=%s;\ncd %s;\nfslmaths %s -nan -thr 0',par.fsl_output_format,pp{1},fo{1});
 % cmd = sprintf('cur_dir=pwd;\nexport FSLOUTPUTTYPE=%s;\ncd %s;\nfslmaths %s -nan -thr 0;\n cd $cur_dir',par.fsl_output_format,pp{1},fo{1});
 if length(fo)==1 %this is a 4D volume
-    cmd = sprintf('%s -Tmean %s\n',cmd,outname);
+    cmd = sprintf('%s -Tmean %s;\n',cmd,outname);
 else
     
     for k=2:length(fo)
@@ -46,6 +48,7 @@ else
     
     cmd = sprintf('%s\nfslmaths %s -div  %d %s -odt float',cmd,outname,length(fo),outname);
 end
+
 
 job{1}=cmd;
 
@@ -60,4 +63,7 @@ switch par.fsl_output_format
 end
 out = [outname ext];
 
-do_cmd_sge(job,par);
+job = do_cmd_sge(job,par,jobappend);
+
+end % function
+

--- a/Wrappers/do_fsl_merge.m
+++ b/Wrappers/do_fsl_merge.m
@@ -1,6 +1,8 @@
-function job = do_fsl_merge(fo,outname,par)
+function job = do_fsl_merge(fo,outname,par,jobappend)
 
 if ~exist('par'),par ='';end
+if ~exist('jobappend','var'), jobappend ='';end
+
 defpar.sge=0;
 defpar.software = 'fsl'; %to set the path
 defpar.software_version = 5; % 4 or 5 : fsl version
@@ -12,7 +14,7 @@ par = complet_struct(par,defpar);
 if iscell(outname)
     %recursiv call
     for kk=1:length(outname)
-       job(kk) = do_fsl_merge(fo{kk},outname{kk},par);
+        job(kk) = do_fsl_merge(fo{kk},outname{kk},par);
     end
     return
 end
@@ -23,19 +25,20 @@ cmd = sprintf('fslmerge -t %s ',outname);
 
 %check vol info
 if par.checkorient
-for k=2:length(fo)
-    if compare_orientation(fo(1),fo(k)) == 0
-        error('volume %s and %s have different orientation or dimension',fo{1},fo{k})        
-        %return
+    for k=2:length(fo)
+        if compare_orientation(fo(1),fo(k)) == 0
+            error('volume %s and %s have different orientation or dimension',fo{1},fo{k})
+            %return
+        end
     end
 end
-end
 
-for k=1:length(fo)    
-  cmd = sprintf('%s %s',cmd,fo{k});
+for k=1:length(fo)
+    cmd = sprintf('%s %s',cmd,fo{k});
 end
 
 job = {cmd};
 
-do_cmd_sge(job,par);
+job = do_cmd_sge(job,par,jobappend);
 
+end % function

--- a/Wrappers/do_fsl_reslice.m
+++ b/Wrappers/do_fsl_reslice.m
@@ -13,7 +13,6 @@ defpar.sge = 0;
 defpar.jobname='fsl_reslice';
 defpar.fsl_output_format = 'NIFTI_GZ';
 defpar.outfilename='' ;
-defpar.do_topup_unwarp_4D = 0;
 
 par = complet_struct(par,defpar);
 

--- a/Wrappers/do_fsl_reslice.m
+++ b/Wrappers/do_fsl_reslice.m
@@ -1,8 +1,10 @@
-function fo = do_fsl_reslice(src,ref,par) % prefix,interp_fsl)
+function [ fo, job ] = do_fsl_reslice(src,ref,par,jobappend) % prefix,interp_fsl)
 %function fo = do_fsl_reslice(src,ref,prefix)
 %if iscell(prefix) prefix is then the matrix output
 
 if ~exist('par'),par ='';end
+if ~exist('jobappend','var'), jobappend ='';end
+
 
 defpar.prefix = 'rfsl_';
 defpar.interp_fsl = 'trilinear'; % trilinear nearestneighbour sinc spline
@@ -11,6 +13,7 @@ defpar.sge = 0;
 defpar.jobname='fsl_reslice';
 defpar.fsl_output_format = 'NIFTI_GZ';
 defpar.outfilename='' ;
+defpar.do_topup_unwarp_4D = 0;
 
 par = complet_struct(par,defpar);
 
@@ -57,5 +60,6 @@ else
     
 end
 
-do_cmd_sge(job,par);
+job = do_cmd_sge(job,par,jobappend);
 
+end % function

--- a/Wrappers/do_fsl_topup.m
+++ b/Wrappers/do_fsl_topup.m
@@ -4,7 +4,7 @@ if ~exist('par'),par ='';end
 if ~exist('jobappend','var'), jobappend ='';end
 
 defpar.outsuffix = '_topup';
-defpar.sge=1;
+defpar.sge=0;
 defpar.jobname='topup';
 defpar.walltime='12:00:00';
 par = complet_struct(par,defpar);
@@ -14,9 +14,13 @@ for k=1:length(f4D)
     [outdir fin] = fileparts(f4D{k});  fin = change_file_extension(fin,'');  %pour le .nii.gz
     fo = [fin  par.outsuffix];
     
-    cmd = sprintf('cd %s;\ntopup --imain=%s --datain=%s --config=%s --out=%s --fout=field_%s --iout=unwarp_%s\n',...
+    cmd = sprintf('cd %s;\ntopup --imain=%s --datain=%s --config=%s --out=%s --fout=field_%s --iout=unwarp_%s;\n',...
+        outdir,fin,'acqp.txt','b02b0.cnf',fo,fo,fo);
+    cmd = sprintf('cd %s;\ntopup --imain=%s --datain=%s --config=%s --out=%s --fout=field_%s --iout=unwarp_%s;\n',...
         outdir,fin,'acqp.txt','b02b0.cnf',fo,fo,fo);
     job{k} = cmd;
 end
 
 j=do_cmd_sge(job,par,jobappend);
+
+end % function

--- a/Wrappers/do_fsl_topup.m
+++ b/Wrappers/do_fsl_topup.m
@@ -16,8 +16,7 @@ for k=1:length(f4D)
     
     cmd = sprintf('cd %s;\ntopup --imain=%s --datain=%s --config=%s --out=%s --fout=field_%s --iout=unwarp_%s;\n',...
         outdir,fin,'acqp.txt','b02b0.cnf',fo,fo,fo);
-    cmd = sprintf('cd %s;\ntopup --imain=%s --datain=%s --config=%s --out=%s --fout=field_%s --iout=unwarp_%s;\n',...
-        outdir,fin,'acqp.txt','b02b0.cnf',fo,fo,fo);
+    
     job{k} = cmd;
 end
 

--- a/init_path_matvol.m
+++ b/init_path_matvol.m
@@ -1,13 +1,6 @@
 function init_path_matvol
 
-if isunix
-    splitter = ':';
-elseif ispc
-    splitter = ';';
-else
-    error('all architectures are not codded yet...')
-end
-paths_to_add = regexp(genpath(matvoldir),splitter,'split');
+paths_to_add = regexp(genpath(matvoldir),pathsep,'split');
 paths_to_add(end) = []; % the last one is always an empty split
 
 regexp_to_take_out = {

--- a/objects/@exam/addModel.m
+++ b/objects/@exam/addModel.m
@@ -30,8 +30,8 @@ for ex = 1 : numel(examArray)
     % Remove duplicates
     if examArray(ex).cfg.remove_duplicates
         
-        if examArray(ex).models.checkTag(tag)
-            examArray(ex).models = examArray(ex).models.removeTag(tag);
+        if examArray(ex).model.checkTag(tag)
+            examArray(ex).model = examArray(ex).model.removeTag(tag);
         end
         
     else
@@ -40,7 +40,7 @@ for ex = 1 : numel(examArray)
         if examArray(ex).cfg.allow_duplicate % yes
             % pass
         else% no
-            if examArray(ex).models.checkTag(tags)
+            if examArray(ex).model.checkTag(tags)
                 continue
             end
         end
@@ -51,7 +51,7 @@ for ex = 1 : numel(examArray)
     modelDir  = get_subdir_regex( examArray(ex).path, recursive_args{:} );
     
     % Be sure to add new model to the modelArray
-    lengthModel = length(examArray(ex).models);
+    lengthModel = length(examArray(ex).model);
     counter     = 0;
     
     % Non-empy Dir ?
@@ -66,7 +66,7 @@ for ex = 1 : numel(examArray)
         try
             SPMfile = get_subdir_regex_files(modelDir,'^SPM.mat$',1);
             counter = counter + 1;
-            examArray(ex).models(lengthModel + counter) = model(char(SPMfile), tag, examArray(ex));
+            examArray(ex).model(lengthModel + counter) = model(char(SPMfile), tag, examArray(ex));
         catch
             warning(['Could not find SPM.mat file in the dir : \n' ...
                 '%s'], char(modelDir))

--- a/objects/@exam/addModel.m
+++ b/objects/@exam/addModel.m
@@ -14,8 +14,6 @@ function varargout = addModel( examArray, varargin)
 
 %% Check inputs
 
-AssertIsExamArray(examArray);
-
 % Need at least dir_regex + tag
 assert( length(varargin)>=2 , '[%s]: requires at least 2 input arguments dir_regex + tag')
 

--- a/objects/@exam/addModel.m
+++ b/objects/@exam/addModel.m
@@ -61,6 +61,7 @@ for ex = 1 : numel(examArray)
                 'Could not find only 1 dir corresponding to the recursive_regex_path : \n'...
                 '%s %s'],...
                 examArray(ex).path, sprintf('%s ', recursive_args{:}))
+            examArray(ex).is_incomplete = 1; % set incomplete flag
         end
         
         try
@@ -70,6 +71,7 @@ for ex = 1 : numel(examArray)
         catch
             warning(['Could not find SPM.mat file in the dir : \n' ...
                 '%s'], char(modelDir))
+            examArray(ex).is_incomplete = 1; % set incomplete flag
         end
         
     else
@@ -77,6 +79,7 @@ for ex = 1 : numel(examArray)
             'Could not find any dir corresponding to the recursive_regex_path : \n'...
             '%s %s'],...
             examArray(ex).path, sprintf('%s ', recursive_args{:}))
+        examArray(ex).is_incomplete = 1; % set incomplete flag
     end
     
     

--- a/objects/@exam/addSerie.m
+++ b/objects/@exam/addSerie.m
@@ -19,8 +19,6 @@ function varargout = addSerie( examArray, varargin)
 
 %% Check inputs
 
-AssertIsExamArray(examArray);
-
 % Need at least dir_regex + tag
 assert( length(varargin)>=2 , '[%s]: requires at least 2 input arguments dir_regex + tag')
 

--- a/objects/@exam/addSerie.m
+++ b/objects/@exam/addSerie.m
@@ -111,6 +111,7 @@ for ex = 1 : numel(examArray)
         
         % Check if N series are found for N tags.
         if checkNr && ( length(serieList) ~= nrSeries )
+            examArray(ex).is_incomplete = 1; % set incomplete flag
             error([
                 'Number of input (%d) tag/nrSeries differs from number of series found \n'...
                 '#%d : %s ' ...

--- a/objects/@exam/addSerie.m
+++ b/objects/@exam/addSerie.m
@@ -82,8 +82,8 @@ for ex = 1 : numel(examArray)
     % Remove duplicates
     if examArray(ex).cfg.remove_duplicates
         
-        if examArray(ex).series.checkTag(tags)
-            examArray(ex).series = examArray(ex).series.removeTag(tags);
+        if examArray(ex).serie.checkTag(tags)
+            examArray(ex).serie = examArray(ex).serie.removeTag(tags);
         end
         
     else
@@ -92,7 +92,7 @@ for ex = 1 : numel(examArray)
         if examArray(ex).cfg.allow_duplicate % yes
             % pass
         else% no
-            if examArray(ex).series.checkTag(tags)
+            if examArray(ex).serie.checkTag(tags)
                 continue
             end
         end
@@ -103,7 +103,7 @@ for ex = 1 : numel(examArray)
     serieList  = get_subdir_regex( examArray(ex).path, recursive_args{:} );
     
     % Be sure to add new series to the serieArray
-    lengthSeries = length(examArray(ex).series);
+    lengthSeries = length(examArray(ex).serie);
     counter      = 0;
     
     % Non-empy list ?
@@ -125,7 +125,7 @@ for ex = 1 : numel(examArray)
             else
                 tag = tags{ser};
             end
-            examArray(ex).series(lengthSeries + counter) = serie(serieList{ser}, tag, examArray(ex) );
+            examArray(ex).serie(lengthSeries + counter) = serie(serieList{ser}, tag, examArray(ex) );
         end % found dir (== series)
         
     else
@@ -141,9 +141,9 @@ for ex = 1 : numel(examArray)
         % Add empty series, but with pointer to the exam : for diagnostic
         for ser = 1 : length(tags)
             counter = counter + 1;
-            examArray(ex).series(lengthSeries + counter)      = serie();
-            examArray(ex).series(lengthSeries + counter).tag  = tags{ser};
-            examArray(ex).series(lengthSeries + counter).exam = examArray(ex);
+            examArray(ex).serie(lengthSeries + counter)      = serie();
+            examArray(ex).serie(lengthSeries + counter).tag  = tags{ser};
+            examArray(ex).serie(lengthSeries + counter).exam = examArray(ex);
         end
         
     end

--- a/objects/@exam/addVolume.m
+++ b/objects/@exam/addVolume.m
@@ -13,8 +13,6 @@ function varargout = addVolume( examArray, series_tag_regex, file_regex, tag, nr
 
 %% Check inputs
 
-AssertIsExamArray(examArray);
-
 AssertIsCharOrCellstr(series_tag_regex);
 
 AssertIsCharOrCellstr(file_regex);

--- a/objects/@exam/exam.m
+++ b/objects/@exam/exam.m
@@ -6,8 +6,8 @@ classdef exam < mvObject
     
     properties
         
-        series = serie.empty % series associated with this exam (See @serie object)
-        models = model.empty % models associated with this exam (See @model object)
+        serie = serie.empty % series associated with this exam (See @serie object)
+        model = model.empty % models associated with this exam (See @model object)
         
         is_incomplete = [];  % this flag will be set to 1 if missing series/volumes
         

--- a/objects/@exam/explore.m
+++ b/objects/@exam/explore.m
@@ -8,7 +8,7 @@ for idx = 1 : numel(obj)
     fprintf('|---idx  = %d \n',idx)
     fprintf('    name = %s \n',obj(idx).name)
     fprintf('    path = %s \n',obj(idx).path)
-    obj(idx).series.explore;
+    obj(idx).serie.explore;
     fprintf('\n')
 end
 

--- a/objects/@exam/explore.m
+++ b/objects/@exam/explore.m
@@ -9,6 +9,7 @@ for idx = 1 : numel(obj)
     fprintf('    name = %s \n',obj(idx).name)
     fprintf('    path = %s \n',obj(idx).path)
     obj(idx).serie.explore;
+    obj(idx).model.explore;
     fprintf('\n')
 end
 

--- a/objects/@exam/getExam.m
+++ b/objects/@exam/getExam.m
@@ -8,8 +8,6 @@ function [ exams ] = getExam( examArray, regex )
 
 %% Check inputs
 
-AssertIsExamArray(examArray);
-
 if nargin < 2
     regex = '.*';
 end

--- a/objects/@exam/getModel.m
+++ b/objects/@exam/getModel.m
@@ -38,14 +38,14 @@ for ex = 1 : numel(examArray)
     
     counter = 0;
     
-    for ser = 1 : numel(examArray(ex).models)
+    for ser = 1 : numel(examArray(ex).model)
         
         if ...
-                ~isempty(examArray(ex).models(ser).(type)) && ...                 % (type) is present in the @model ?
-                ~isempty(regexp(examArray(ex).models(ser).(type), regex, 'once')) % found a corresponding model.(type) to the regex ?
+                ~isempty(examArray(ex).model(ser).(type)) && ...                 % (type) is present in the @model ?
+                ~isempty(regexp(examArray(ex).model(ser).(type), regex, 'once')) % found a corresponding model.(type) to the regex ?
             
             counter = counter + 1;
-            modelArray(ex,counter) = examArray(ex).models(ser);
+            modelArray(ex,counter) = examArray(ex).model(ser);
             
         end
         

--- a/objects/@exam/getModel.m
+++ b/objects/@exam/getModel.m
@@ -6,8 +6,6 @@ function [ modelArray ] = getModel( examArray, regex, type )
 
 %% Check inputs
 
-AssertIsExamArray(examArray);
-
 if nargin < 2
     regex = '.*';
 end

--- a/objects/@exam/getSerie.m
+++ b/objects/@exam/getSerie.m
@@ -8,8 +8,6 @@ function [ serieArray ] = getSerie( examArray, regex, type )
 
 %% Check inputs
 
-AssertIsExamArray(examArray);
-
 if nargin < 2
     regex = '.*';
 end

--- a/objects/@exam/getSerie.m
+++ b/objects/@exam/getSerie.m
@@ -40,14 +40,14 @@ for ex = 1 : numel(examArray)
     
     counter = 0;
     
-    for ser = 1 : numel(examArray(ex).series)
+    for ser = 1 : numel(examArray(ex).serie)
         
         if ...
-                ~isempty(examArray(ex).series(ser).(type)) && ...                 % (type) is present in the @serie ?
-                ~isempty(regexp(examArray(ex).series(ser).(type), regex, 'once')) % found a corresponding serie.(type) to the regex ?
+                ~isempty(examArray(ex).serie(ser).(type)) && ...                 % (type) is present in the @serie ?
+                ~isempty(regexp(examArray(ex).serie(ser).(type), regex, 'once')) % found a corresponding serie.(type) to the regex ?
             
             counter = counter + 1;
-            serieArray(ex,counter) = examArray(ex).series(ser);
+            serieArray(ex,counter) = examArray(ex).serie(ser);
             
         end
         

--- a/objects/@exam/getStim.m
+++ b/objects/@exam/getStim.m
@@ -7,8 +7,6 @@ function [ volumeArray ] = getStim( examArray, serie_regex, stim_regex, stim_typ
 
 %% Check inputs
 
-AssertIsExamArray(examArray);
-
 if nargin < 2
     serie_regex = '.*';
 end

--- a/objects/@exam/getVolume.m
+++ b/objects/@exam/getVolume.m
@@ -7,8 +7,6 @@ function [ volumeArray ] = getVolume( examArray, serie_regex, volume_regex, volu
 
 %% Check inputs
 
-AssertIsExamArray(examArray);
-
 if nargin < 2
     serie_regex = '.*';
 end

--- a/objects/@exam/removeIncomplete.m
+++ b/objects/@exam/removeIncomplete.m
@@ -1,8 +1,11 @@
-function [ completeExams, incompleteExams ] = removeIncomplete( examArray )
-% REMOVEINCOMPLETE method removes incomplet @exams accoding to their flag .is_complete
-% IMPORTANT : This method requires an output argument, and will not affect the input
-% (due to MATLAB object behaviour).
-% Also, you can keep the incomplete exams (second output).
+function [ completeExams, incompleteExams ] = removeIncomplete( examArray, do_deep_copy, verbose )
+% REMOVEINCOMPLETE method sorts out complete and incomplete @exams according to their flag .is_complete
+%
+% SYNTAX : [ completeExams, incompleteExams ] = removeIncomplete( examArray, do_deep_copy=0/1, verbose=0/1 )
+%
+% VERY IMPORTANT : use 'do_deep_copy' flag to make deep copy of object (or not)
+% Note : This method requires an output argument.
+%
 
 AssertIsExamArray(examArray);
 
@@ -10,17 +13,44 @@ if nargout < 1
     error('[%s]: At least one output argument is required', mfilename)
 end
 
-completeExams   = examArray;  % NOT a deep copy of the array, just pointer copy
-incompleteExams = exam.empty; % empty array
-
-for ex = length(examArray) : -1 : 1
-    if examArray(ex).is_incomplete
-        fprintf('\n')
-        fprintf('[%s]: The exam #%d will be removed : \n', mfilename, ex)
-        examArray(ex).explore
-        completeExams(ex) = [];
-        incompleteExams(end+1,1) = examArray(ex); %#ok<AGROW>
-    end
+if nargin < 3
+    verbose = 0;
 end
+
+if nargin < 2
+    do_deep_copy = 1;
+end
+
+
+%% Sort out
+
+flags = {examArray.is_incomplete}; % { [] []  1 [] ...}
+where = cellfun(@isempty, flags);  % [  1  1  0  1 ...]
+
+if do_deep_copy
+    
+    % Deep copy
+    completeExams   = examArray.copyObject;
+    incompleteExams = examArray.copyObject;
+    
+else
+    
+    % Pointer copy
+    completeExams   = examArray;
+    incompleteExams = examArray;
+    
+end
+
+% Sort out
+completeExams   = completeExams  ( where);
+incompleteExams = incompleteExams(~where);
+
+if verbose
+    fprintf('\n')
+    fprintf('[%s]: The exam(s) bellow will be removed : \n', mfilename)
+    disp(find(~where))
+    incompleteExams.explore
+end
+
 
 end % function

--- a/objects/@exam/removeIncomplete.m
+++ b/objects/@exam/removeIncomplete.m
@@ -10,7 +10,7 @@ if nargout < 1
     error('[%s]: At least one output argument is required', mfilename)
 end
 
-completeExams   = examArray;  % deep copy of the array
+completeExams   = examArray;  % NOT a deep copy of the array, just pointer copy
 incompleteExams = exam.empty; % empty array
 
 for ex = length(examArray) : -1 : 1

--- a/objects/@exam/removeIncomplete.m
+++ b/objects/@exam/removeIncomplete.m
@@ -19,7 +19,7 @@ for ex = length(examArray) : -1 : 1
         fprintf('[%s]: The exam #%d will be removed : \n', mfilename, ex)
         examArray(ex).explore
         completeExams(ex) = [];
-        incompleteExams(end+1) = examArray(ex); %#ok<AGROW>
+        incompleteExams(end+1,1) = examArray(ex); %#ok<AGROW>
     end
 end
 

--- a/objects/@exam/removeIncomplete.m
+++ b/objects/@exam/removeIncomplete.m
@@ -7,8 +7,6 @@ function [ completeExams, incompleteExams ] = removeIncomplete( examArray, do_de
 % Note : This method requires an output argument.
 %
 
-AssertIsExamArray(examArray);
-
 if nargout < 1
     error('[%s]: At least one output argument is required', mfilename)
 end

--- a/objects/@exam/reorderSeries.m
+++ b/objects/@exam/reorderSeries.m
@@ -5,8 +5,6 @@ function reorderSeries( examArray, kind )
 
 %% Check input arguments
 
-AssertIsExamArray(examArray)
-
 if nargin < 2
     kind = 'name';
 end

--- a/objects/@exam/reorderSeries.m
+++ b/objects/@exam/reorderSeries.m
@@ -15,7 +15,7 @@ end
 %% Do the reorder over all exams
 
 for ex = 1 : numel(examArray)
-    examArray(ex).series = examArray(ex).series.reorder(kind);
+    examArray(ex).serie = examArray(ex).serie.reorder(kind);
 end
 
 

--- a/objects/@exam/unzipVolume.m
+++ b/objects/@exam/unzipVolume.m
@@ -1,8 +1,6 @@
 function unzipVolume( examArray )
 %UNZIPVOLUME Unzips all volumes in the examArray
 
-AssertIsExamArray(examArray)
-
 % Use the method from unzip
 examArray.getVolume.unzip
 

--- a/objects/@model/explore.m
+++ b/objects/@model/explore.m
@@ -1,0 +1,9 @@
+function explore( obj )
+% EXPLORE method displays the content of the object
+
+for idx = 1 : numel(obj)
+    %     cprintf('[0.1,0.5,0]','    *** %s -> %s \n', obj(idx).tag, obj(idx).name)
+    fprintf('    *** %s -> %s \n', obj(idx).tag, obj(idx).name)
+end
+
+end % function

--- a/objects/@mvObject/changePath.m
+++ b/objects/@mvObject/changePath.m
@@ -1,0 +1,54 @@
+function [ pathArray ] = changePath( mvArray, oldpath, newpath )
+%CHANGEPATH
+
+%% Check input
+
+assert( nargin==3, 'oldpath & newpath must be defined, as char or cellstr' )
+
+AssertIsCharOrCellstr(oldpath)
+AssertIsCharOrCellstr(newpath)
+
+oldpath = char(oldpath);
+newpath = char(newpath);
+
+
+%% Routine
+
+% Output
+pathArray = cell( size(mvArray) );
+
+classname = class(mvArray);
+
+for idx = 1 : numel( mvArray )
+    
+    if ~isempty(mvArray(idx).path)
+        
+        % regexprep
+        mvArray(idx).path = char(regexprep(cellstr(mvArray(idx).path), oldpath, newpath));
+        
+        % Save new path in output
+        pathArray{idx} = mvArray(idx).path;
+        
+        % Recursivity
+        switch classname
+            case 'exam'
+                mvArray(idx).serie.changePath( oldpath, newpath );
+                mvArray(idx).model.changePath( oldpath, newpath );
+            case 'serie'
+                mvArray(idx).volume.changePath( oldpath, newpath );
+                mvArray(idx).stim  .changePath( oldpath, newpath );
+            case 'model'
+                % pass
+            case 'volume'
+                % pass
+            case 'stim'
+                % pass
+            otherwise
+                warning('non-coded routine for the object')
+        end
+        
+    end
+    
+end % for
+
+end % function

--- a/objects/@mvObject/checkIntegrity.m
+++ b/objects/@mvObject/checkIntegrity.m
@@ -1,0 +1,45 @@
+function [ resultArray ] = checkIntegrity( mvArray )
+%CHECKINTEGRITY verify if all mvObject.path exist recursively
+
+resultArray = nan( size(mvArray) );
+
+classname = class(mvArray);
+
+for idx = 1 : numel( mvArray )
+    
+    
+    if ~isempty(mvArray(idx).path)
+        
+        result = exist(deblank(mvArray(idx).path(1,:))) ~= 0; %#ok<EXIST>
+        
+        % Recursivity
+        if result == 1
+            
+            switch classname
+                case 'exam'
+                    res1 = mvArray(idx).serie.checkIntegrity;
+                    res2 = mvArray(idx).model.checkIntegrity;
+                    result = all([res1 res2]);
+                case 'serie'
+                    res1 = mvArray(idx).volume.checkIntegrity;
+                    res2 = mvArray(idx).stim  .checkIntegrity;
+                    result = all([res1 res2]);
+                case 'model'
+                    % pass
+                case 'volume'
+                    % pass
+                case 'stim'
+                    % pass
+                otherwise
+                    warning('non-coded routine for the object')
+            end
+            
+        end % reccursivity, when necessary
+        
+        resultArray(idx) = result;
+        
+    end % non empty path
+    
+end % for
+
+end % function

--- a/objects/@mvObject/copyObject.m
+++ b/objects/@mvObject/copyObject.m
@@ -1,0 +1,101 @@
+function [ out ] = copyObject( in , varargin )
+%COPYOBJECT make a deep copy of the object, not just a pointer managment.
+%
+% Syntax : newMvArray = oldMvArray.copyObject();
+%
+% Warning : the argument "varargin" is reserved for internal purpose, do not use it.
+% 
+
+className = class(in);
+
+% Prepare copy of potential objects inside (recursivity)
+switch class(in)
+    case 'exam'
+        do_not_copy  = {};                 % up, copy pointers
+        to_deep_copy = {'serie', 'model'}; % down, deep copy
+        send_ptr     = {'exam'};           % send down pointers
+    case 'serie'
+        do_not_copy  = {'exam'};
+        to_deep_copy = {'volume', 'stim'};
+        send_ptr     = {'exam', 'serie'};
+    case 'volume'
+        do_not_copy  = {'exam', 'serie'};
+        to_deep_copy = {};
+        send_ptr     = {'exam', 'serie', 'volume'};
+    case 'stim'
+        do_not_copy  = {'exam', 'serie'};
+        to_deep_copy = {};
+        send_ptr     = {'exam', 'serie'};
+    case 'model'
+        do_not_copy  = {'exam'};
+        to_deep_copy = {};
+        send_ptr     = {'exam', 'model'};
+    otherwise
+        error('Unknown object class. Is it really an mvObject ?')
+end
+
+% Empty array of object, happens when copy a 0x0 array
+if numel(in) == 0
+    out = eval([className '.empty']);
+end
+
+for idx = 1:numel(in)
+    
+    % New object, empty
+    out(idx) = eval(className);
+    
+    % Pointer copy : receive from upper objects (containers)
+    if ~isempty(varargin) && ~isempty(varargin{1})
+        for var = 1 : numel(varargin{1})
+            upperclassName = class(varargin{1}{var});
+            out(idx).(upperclassName) = varargin{1}{var};
+            assert( out(idx).(upperclassName) ~= in(idx).(upperclassName) , 'Problem in the copy of prointers from upper container' )
+        end
+    end
+    
+    % Pointer copy : send to next
+    ptrArray = cell(size(send_ptr));
+    if ~isempty(send_ptr)
+        for ptr = 1 : length(send_ptr)
+            if strcmp(send_ptr{ptr},className)
+                ptrArray{ptr} = out(idx);
+                assert( out(idx) ~= in(idx) , 'Problem in the copy of prointers in the current object' )
+            else
+                ptrArray{ptr} = out(idx).(send_ptr{ptr});
+                assert( out(idx).(send_ptr{ptr}) ~= in(idx).(send_ptr{ptr}) , 'Problem in the copy of prointers in the current object' )
+            end
+        end
+    end
+    
+    % Deep copy of objects
+    for obj = 1 : length(to_deep_copy)
+        out(idx).(to_deep_copy{obj}) = in(idx).(to_deep_copy{obj}).copyObject( ptrArray );
+        assert( all( out(idx).(to_deep_copy{obj}) ~= in(idx).(to_deep_copy{obj}) ) , 'Problem in deep copy output from lower object' )
+    end
+    
+    % Copy of non-objects
+    propName = properties( in );
+    for l =  1:length(to_deep_copy)
+        where_cell = regexp(propName,to_deep_copy{l},'once');
+        where_idx = cellfun( @isempty, where_cell, 'uniformoutput', 1);
+        propName = propName(where_idx);
+    end
+    for l =  1:length(do_not_copy)
+        where_cell = regexp(propName,do_not_copy{l},'once');
+        where_idx = cellfun( @isempty, where_cell, 'uniformoutput', 1);
+        propName = propName(where_idx);
+    end
+    for prop = 1 : length(propName)
+        out(idx).(propName{prop}) = in(idx).(propName{prop});
+    end
+    
+end % in(idx)
+
+if isa(in,'exam')
+    out = out';
+end
+
+% Check if a real deep copy has been done
+assert( ~any(out==in) , 'Not a deep copy for the object %s ', className )
+
+end % function

--- a/objects/@mvObject/la.m
+++ b/objects/@mvObject/la.m
@@ -1,4 +1,5 @@
 function la( mvArray )
+% ls -AFh
 
 mvArray.unix('ls -AFh')
 

--- a/objects/@mvObject/ll.m
+++ b/objects/@mvObject/ll.m
@@ -1,4 +1,5 @@
 function ll( mvArray )
+% ls -lFh
 
 mvArray.unix('ls -lFh')
 

--- a/objects/@mvObject/lla.m
+++ b/objects/@mvObject/lla.m
@@ -1,4 +1,5 @@
 function lla( mvArray )
+% ls -AlFh
 
 mvArray.unix('ls -AlFh')
 

--- a/objects/@mvObject/ls.m
+++ b/objects/@mvObject/ls.m
@@ -1,4 +1,5 @@
 function ls( mvArray )
+% ls -CF
 
 mvArray.unix('ls -CF')
 

--- a/objects/@mvObject/ltr.m
+++ b/objects/@mvObject/ltr.m
@@ -1,4 +1,5 @@
 function ltr( mvArray )
+% ls -AlFtrh
 
 mvArray.unix('ls -AlFtrh')
 

--- a/objects/@mvObject/methods.m
+++ b/objects/@mvObject/methods.m
@@ -1,0 +1,26 @@
+function methods( self )
+%METHODS prints the methods of the object
+
+class_name = class( self );
+class_dir  = fileparts( which( class_name ) );
+class_meth = dir(class_dir);
+class_meth = class_meth(3:end); % remoce . and ..
+class_meth = {class_meth.name};
+class_meth = regexprep(class_meth,'\.m','');
+
+sc_names   = superclasses(class_name);
+sc_dir     = fileparts( which( sc_names{1} ) );
+sc_meth    = dir(sc_dir);
+sc_meth    = sc_meth(3:end); % remoce . and ..
+sc_meth    = {sc_meth.name};
+sc_meth    = regexprep(sc_meth,'\.m','');
+
+fprintf('----- \n')
+fprintf('Class %s methods are : \n', upper(class_name))
+fprintf('%s \n', class_meth{:})
+
+fprintf('---------- \n')
+fprintf('Superclass %s methods are : \n', upper(sc_names{1}))
+fprintf('%s \n', sc_meth{:})
+
+end % functon

--- a/objects/@mvObject/minus.m
+++ b/objects/@mvObject/minus.m
@@ -3,7 +3,7 @@ function [ out ] = minus( mvArray_1, mvArray_2 )
 %
 % Syntax : newArray = mvArray_1 - mvArray_2
 %
-% This operatior will remove the objects in mvArray_1 corresponding to the any tag of mvArray_2
+% This operatior will remove the objects in mvArray_1 corresponding to any tag of mvArray_2
 %
 
 assert( isa(mvArray_2,'mvObject') , 'can only use @mvObject for this operation')

--- a/objects/@mvObject/minus.m
+++ b/objects/@mvObject/minus.m
@@ -1,0 +1,15 @@
+function [ out ] = minus( mvArray_1, mvArray_2 )
+%MINUS operator
+%
+% Syntax : newArray = mvArray_1 - mvArray_2
+%
+% This operatior will remove the objects in mvArray_1 corresponding to the any tag of mvArray_2
+%
+
+assert( isa(mvArray_2,'mvObject') , 'can only use @mvObject for this operation')
+
+assert( strcmp(class(mvArray_1),class(mvArray_2)) , 'can only use the same object for this operation' )
+
+out = mvArray_1.removeTag( {mvArray_2.tag} );
+
+end % function

--- a/objects/@mvObject/mkdir.m
+++ b/objects/@mvObject/mkdir.m
@@ -1,4 +1,4 @@
-function mkdir( mvArray , varargin )
+function out = mkdir( mvArray , varargin )
 %MKDIR creates dir contained in varargin, starting for the current self.path
 % If the self.path is a dir , a subdir will be created.
 % If the self.path is a file, a subdir will be created next to it.
@@ -28,6 +28,7 @@ else
     lastDir        = fullfile(varargin{end});
 end
 
+out = cell(numel(mvArray),1);
 
 for idx = 1 : numel(mvArray)
     
@@ -42,7 +43,7 @@ for idx = 1 : numel(mvArray)
             error('Nature not defined for %s', mvArray(idx).path)
     end
     
-    r_mkdir(baseDir,fullfile(intermediatDir,lastDir));
+    out{idx} = char(r_mkdir(baseDir,fullfile(intermediatDir,lastDir)));
     
 end
 

--- a/objects/@mvObject/mkdir.m
+++ b/objects/@mvObject/mkdir.m
@@ -1,0 +1,49 @@
+function mkdir( mvArray , varargin )
+%MKDIR creates dir contained in varargin, starting for the current self.path
+% If the self.path is a dir , a subdir will be created.
+% If the self.path is a file, a subdir will be created next to it.
+%
+%   exemple :
+%       mvArray.mkdir('subdir1','subdir2',..., 'subdirN'           )
+%       mvArray.mkdir('subdir1','subdir2',...,{'subdirA','subdirB'})
+%
+%
+
+assert( ~isempty(varargin)  , 'subdirs are required' )
+
+% Restriction : only the last argument can be cellstr for multiple mkdir
+for v =  1 : length(varargin)
+    if v ~= length(varargin)
+        assert( ischar(varargin{v}) , 'arguments must be char' )
+    else % the last one
+        assert( ischar(varargin{v})||iscellstr(varargin{v}) , 'last argument can be char or cellstr' )
+    end
+end
+
+if length(varargin) == 1
+    intermediatDir = '';
+    lastDir        = fullfile(varargin{end});
+else
+    intermediatDir = fullfile(varargin{1:end-1});
+    lastDir        = fullfile(varargin{end});
+end
+
+
+for idx = 1 : numel(mvArray)
+    
+    switch exist(mvArray(idx).path) %#ok<EXIST>
+        case 0 % nothing
+            error('%s is not valid', mvArray(idx).path)
+        case 2 % file
+            baseDir = get_parent_path(mvArray(idx).path);
+        case 7 % dir
+            baseDir = mvArray(idx).path;
+        otherwise
+            error('Nature not defined for %s', mvArray(idx).path)
+    end
+    
+    r_mkdir(baseDir,fullfile(intermediatDir,lastDir));
+    
+end
+
+end % function

--- a/objects/@mvObject/plus.m
+++ b/objects/@mvObject/plus.m
@@ -1,0 +1,13 @@
+function [ out ] = plus( mvArray_1, mvArray_2 )
+%PLUS operator
+%
+% Syntax : newArray = mvArray_1 + mvArray_2
+%
+
+assert( isa(mvArray_2,'mvObject') , 'can only use @mvObject for this operation')
+
+assert( strcmp(class(mvArray_1),class(mvArray_2)) , 'can only use the same object for this operation' )
+
+out = [mvArray_1 ; mvArray_2];
+
+end % function

--- a/objects/@mvObject/toJob.m
+++ b/objects/@mvObject/toJob.m
@@ -5,8 +5,6 @@ function [ pathArray ] = toJob( mvArray, flag )
 
 %% Check input arguments
 
-assert( isa(mvArray,'exam') || isa(mvArray,'serie') || isa(mvArray,'volume') || isa(mvArray,'stim') || isa(mvArray,'model') )
-
 if nargin < 2
     switch class(mvArray)
         case 'exam'
@@ -19,6 +17,8 @@ if nargin < 2
             flag = 0;
         case 'model'
             flag = 0;
+        otherwise
+            error('Unknown object class. Is it really an mvObject ?')
     end
 end
 

--- a/objects/@serie/addStim.m
+++ b/objects/@serie/addStim.m
@@ -21,8 +21,6 @@ function varargout = addStim( serieArray, stimPath, regex, tag, nrStim )
 
 %% Check inputs
 
-AssertIsSerieArray(serieArray);
-
 assert( ischar(stimPath) && ~isempty(stimPath) , 'stimPath must be a non-empty char' )
 assert( ischar(regex    ) && ~isempty(regex  ) , 'regex must be a non-empty char'    )
 assert( ischar(tag      ) && ~isempty(tag    ) , 'tag must be a non-empty char'      )

--- a/objects/@serie/addVolume.m
+++ b/objects/@serie/addVolume.m
@@ -12,8 +12,6 @@ function varargout = addVolume( serieArray, file_regex, tag, nrVolumes )
 
 %% Check inputs
 
-AssertIsSerieArray(serieArray);
-
 assert( ischar(file_regex) && ~isempty(file_regex) , 'file_regex must be a non-empty char', file_regex )
 assert( ischar(tag       ) && ~isempty(tag       ) , 'tag must be a non-empty char'       , tag        )
 

--- a/objects/@serie/addVolume.m
+++ b/objects/@serie/addVolume.m
@@ -31,8 +31,8 @@ for ser = 1 : numel(serieArray)
     % Remove duplicates
     if serieArray(ser).cfg.remove_duplicates
         
-        if serieArray(ser).volumes.checkTag(tag)
-            serieArray(ser).volumes = serieArray(ser).volumes.removeTag(tag);
+        if serieArray(ser).volume.checkTag(tag)
+            serieArray(ser).volume = serieArray(ser).volume.removeTag(tag);
         end
         
     else
@@ -41,7 +41,7 @@ for ser = 1 : numel(serieArray)
         if serieArray(ser).cfg.allow_duplicate % yes
             % pass
         else% no
-            if serieArray(ser).volumes.checkTag(tag)
+            if serieArray(ser).volume.checkTag(tag)
                 continue
             end
         end
@@ -54,7 +54,7 @@ for ser = 1 : numel(serieArray)
         volume_found = get_subdir_regex_files(serieArray(ser).path,file_regex,par); % error from this function if not found
         
         % Volume found, so add it
-        serieArray(ser).volumes(end + 1) = volume(char(volume_found), tag, serieArray(ser).exam , serieArray(ser));
+        serieArray(ser).volume(end + 1) = volume(char(volume_found), tag, serieArray(ser).exam , serieArray(ser));
         
     catch
         

--- a/objects/@serie/explore.m
+++ b/objects/@serie/explore.m
@@ -4,7 +4,7 @@ function explore( obj )
 for idx = 1 : numel(obj)
     %     cprintf('[0.1,0.5,0]','    +++ %s -> %s \n', obj(idx).tag, obj(idx).name)
     fprintf('    +++ %s -> %s \n', obj(idx).tag, obj(idx).name)
-    obj(idx).volumes.explore;
+    obj(idx).volume.explore;
     obj(idx).stim.explore;
 end
 

--- a/objects/@serie/getStim.m
+++ b/objects/@serie/getStim.m
@@ -8,8 +8,6 @@ function [ stimArray ] = getStim( serieArray, regex, type )
 
 %% Check inputs
 
-AssertIsSerieArray(serieArray);
-
 if nargin < 2
     regex = '.*';
 end

--- a/objects/@serie/getVolume.m
+++ b/objects/@serie/getVolume.m
@@ -40,17 +40,17 @@ for ex = 1 : size(serieArray,1)
         
         counter = 0;
         
-        for vol = 1 : numel(serieArray(ex,ser).volumes)
+        for vol = 1 : numel(serieArray(ex,ser).volume)
             
             if ...
-                    ~isempty(serieArray(ex,ser).volumes(vol).(type)) && ...                      % (type) is present in the @volume ?
-                    ~isempty(regexp(serieArray(ex,ser).volumes(vol).(type)(1,:), regex, 'once')) % found a corresponding volume.(type) to the regex ?
+                    ~isempty(serieArray(ex,ser).volume(vol).(type)) && ...                      % (type) is present in the @volume ?
+                    ~isempty(regexp(serieArray(ex,ser).volume(vol).(type)(1,:), regex, 'once')) % found a corresponding volume.(type) to the regex ?
                 
                 % Above is a problem : I only scan the first line of char array : regexp doesnt work on char array, only char vector
                 % It could also work if we scan over a cellstr, but the management would bring other problems : which line to take into account ?
                 
                 counter = counter + 1;
-                volumeArray(ex,ser,counter) = serieArray(ex,ser).volumes(vol);
+                volumeArray(ex,ser,counter) = serieArray(ex,ser).volume(vol);
                 
             end
             

--- a/objects/@serie/getVolume.m
+++ b/objects/@serie/getVolume.m
@@ -7,8 +7,6 @@ function [ volumeArray ] = getVolume( serieArray, regex, type )
 
 %% Check inputs
 
-AssertIsSerieArray(serieArray);
-
 if nargin < 2
     regex = '.*';
 end

--- a/objects/@serie/plotRealign.m
+++ b/objects/@serie/plotRealign.m
@@ -2,9 +2,6 @@ function plotRealign( serieArray )
 % PLOTREALIGN plots the realignment paramters for EPI sequences
 % Plots all series for each exam
 
-%% Check inputs
-AssertIsSerieArray(serieArray)
-
 
 %% plotRealign
 

--- a/objects/@serie/reorder.m
+++ b/objects/@serie/reorder.m
@@ -4,7 +4,6 @@ function serieArray = reorder( serieArray, kind )
 
 %% Check input arguments
 
-AssertIsSerieArray(serieArray)
 assert( nargin>1 && ( ischar(kind) ) && ~isempty(kind) , 'kind must be defined and a non-empty char ')
 
 

--- a/objects/@serie/serie.m
+++ b/objects/@serie/serie.m
@@ -3,9 +3,9 @@ classdef serie < mvObject
     
     properties
         
-        volumes = volume.empty % volumes associated with this serie
-        exam    = exam.empty   % exam    associated with this serie
-        stim    = stim.empty   % stim    associated with this serie
+        volume = volume.empty % volumes associated with this serie
+        exam   = exam.empty   % exam    associated with this serie
+        stim   = stim.empty   % stim    associated with this serie
         
     end
     

--- a/objects/@stim/load.m
+++ b/objects/@stim/load.m
@@ -1,0 +1,12 @@
+function [ stimstruct ] = load( stimArray )
+%LOAD the variables of the .mat file in the current workspace
+
+stimstruct = cell(numel(stimArray),1);
+
+for idx = 1 : numel(stimArray)
+    
+    stimstruct{idx} = load(stimArray(idx).path);
+    
+end % for all objects in stimArray
+
+end % function

--- a/objects/@stim/load.m
+++ b/objects/@stim/load.m
@@ -5,7 +5,9 @@ stimstruct = cell(numel(stimArray),1);
 
 for idx = 1 : numel(stimArray)
     
-    stimstruct{idx} = load(stimArray(idx).path);
+    if ~isempty(stimArray(idx).path)
+        stimstruct{idx} = load(stimArray(idx).path);
+    end
     
 end % for all objects in stimArray
 

--- a/objects/@volume/checkreg.m
+++ b/objects/@volume/checkreg.m
@@ -9,7 +9,6 @@ function checkreg( volumeArray, center, fov, resolution )
 % For the moment, there is no easy method to overide the maxium image displayed.
 % This limit value (24 in my case) is hard coded in spm_orthviews -> max_img
 
-AssertIsVolumeArray(volumeArray);
 
 % Remove the empty volumes.path from volumeArray
 list = volumeArray.print;

--- a/objects/@volume/mpower.m
+++ b/objects/@volume/mpower.m
@@ -2,9 +2,6 @@ function [ interleavedVolArray ] = mpower( volArray_1, volArray_2 )
 %MPOWER concatenates + interleave the two inputs
 % Syntax : interleavedVolArray = volArray_1 ^ volArray_2
 
-AssertIsVolumeArray(volArray_1)
-AssertIsVolumeArray(volArray_2)
-
 assert( numel(volArray_1) == numel(volArray_2) , '[InterleaveVolumeArray]: volumeArray must have the same numel' )
 
 % Empty @volume array

--- a/objects/@volume/removeGZ.m
+++ b/objects/@volume/removeGZ.m
@@ -1,7 +1,6 @@
 function removeGZ( volumeArray )
 % REMOVEGZ removes .gz from each file name inside the volumeArray, if needed.
 
-AssertIsVolumeArray(volumeArray)
 
 for vol = 1 : numel(volumeArray)
     

--- a/objects/@volume/show.m
+++ b/objects/@volume/show.m
@@ -39,7 +39,6 @@ function show( volumeArray, viewer )
 
 %% Check input arguments
 
-AssertIsVolumeArray(volumeArray);
 volumeArray = shiftdim(volumeArray,1); % need to shift dimensions to have the volumes displayed in meaningful order.
 
 if numel(volumeArray) == 0

--- a/objects/@volume/unzip.m
+++ b/objects/@volume/unzip.m
@@ -1,7 +1,6 @@
 function unzip( volumeArray )
 % UNZIP unzip volumes, if needed.
 
-AssertIsVolumeArray(volumeArray)
 
 if ~isempty(volumeArray)
     unzip_volume(volumeArray.toJob);

--- a/objects/AssertIsExamArray.m
+++ b/objects/AssertIsExamArray.m
@@ -1,5 +1,0 @@
-function AssertIsExamArray( input )
-
-assert( isa(input,'exam'), 'examArray must be an array of @exam objects' )
-
-end % function

--- a/objects/AssertIsSerieArray.m
+++ b/objects/AssertIsSerieArray.m
@@ -1,5 +1,0 @@
-function AssertIsSerieArray( input )
-
-assert( isa(input,'serie'), 'examArray must be an array of @serie objects' )
-
-end % function

--- a/objects/AssertIsVolumeArray.m
+++ b/objects/AssertIsVolumeArray.m
@@ -1,5 +1,0 @@
-function AssertIsVolumeArray( input )
-
-assert( isa(input,'volume'), 'examArray must be an array of @volume objects' )
-
-end % function


### PR DESCRIPTION
- new `mvObject/methods` to print methods specific to the object
- new `mvObject/copyObject` to deep copy the object
- added `model/explore`
- added` stim/load`
- more flexibility for` get_string_json`
- TR is checked in `job_first_level_specify`. TR can still be manually defined with `par.TR = X`
- added `mvObject/mkdir` method 
- Parallel Computing Toolbox : use `par.pct=1` to run the **spm jobs** in a `parfor` loop, and for `do_topup_unwarp_4D`
- `mvObject/mkdir` now has an output
- `is_incomplete` flag is now used in all add* methods
-  `exam/removeIncomplete` can now do deep copy (or not), and has verbose option
- new method `mvObject/checkIntegrity`
- new method `mvObject/changePath`
- new operators : `+` and `-`