### PR TITLE
Dev job obj

### DIFF
--- a/SPM/firstlevel/job_first_level_estimate.m
+++ b/SPM/firstlevel/job_first_level_estimate.m
@@ -23,18 +23,25 @@ par = complet_struct(par,defpar);
 
 %% SPM:Stats:model estimation
 
-for idx = 1:length(fspm)
+skip = [];
 
+for idx = 1:length(fspm)
+    
+    beta_file = fullfile(fileparts(fspm{idx}),'beta_0001.nii');
+    if ~par.redo   &&  exist(beta_file,'file')
+        skip = [skip idx];
+        fprintf('[%s]: skiping subj %d because %s exist \n',mfilename,idx,beta_file);
+    end
+    
     jobs{idx}.spm.stats.fmri_est.spmmat = fspm(idx) ; %#ok<*AGROW>
     jobs{idx}.spm.stats.fmri_est.write_residuals = 0;
     jobs{idx}.spm.stats.fmri_est.method.Classical = 1;
-
-
+    
 end
 
 %% Other routines
 
-[ jobs ] = job_ending_rountines( jobs, [], par );
+[ jobs ] = job_ending_rountines( jobs, skip, par );
 
 
 end % function

--- a/SPM/firstlevel/job_first_level_specify.m
+++ b/SPM/firstlevel/job_first_level_specify.m
@@ -36,105 +36,113 @@ else
     nrSubject=1;
 end
 
+skip = [];
+
 for subj = 1:nrSubject
     
-    % Check of all TR are the same for each run
-    if ~isfield(par,'TR')
+    spm_file = char(addsuffixtofilenames(dirStats(subj),'SPM.mat'));
+    if ~par.redo   &&  exist(spm_file,'file')
+        skip = [skip subj];
+        fprintf('[%s]: skiping subj %d because %s exist \n',mfilename,subj,spm_file);
+    else
         
-        jsons = get_subdir_regex_files( dirFonc{subj} , '^dic.*json$' );
-        if iscell(dirFonc{1})
-            assert( length(dirFonc{subj}) == length(jsons) , 'dic.*json were no found in all volumes' )
-        else
-            assert( length(dirFonc) == length(jsons) , 'dic.*json were no found in all volumes' )
-        end
-        % Multiple json files ? Like multi-echo ?
-        for j = 1 : length(jsons)
-            jsons{j} = jsons{j}(1,:); % only keep the first echo
-        end
-        [ TRs ] = get_string_from_json( jsons , 'RepetitionTime' , 'numeric' );
-        allTR = nan(size(TRs));
-        for idx = 1 : length(allTR)
-            allTR(idx) = TRs{idx}{1};
-        end
-        if iscell(dirFonc{1})
-            assert( all( allTR(1)==allTR ) , 'TR is not the same for each run : %s' , dirFonc{subj}{:} )
-        else
-            assert( all( allTR(1)==allTR ) , 'TR is not the same for each run : %s' , dirFonc{:} )
-        end
-        
-        % Define TR
-        par.TR = allTR(1)/1000; % convert milliseconds into seconds
-        
-    end
-    
-    %     if iscell(dirFonc{1})
-    subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg);
-    unzip_volume(subjectRuns);
-    subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg,struct('verbose',0));
-    if par.rp
-        fileRP = get_subdir_regex_files(dirFonc{subj},par.rp_regex);
-    end
-    %     else
-    %         subjectRuns = dirFonc;
-    %     end
-    
-    % When onsets are inside the .mat file
-    if ~ isstruct(onsets{1})
-        fonset = cellstr(char(onsets(subj)));
-    end
-    
-    for run = 1:length(subjectRuns)
-        currentRun = cellstr(subjectRuns{run}) ;
-        clear allVolumes
-        
-        if length(currentRun) == 1 %4D file
-            allVolumes = spm_select('expand',currentRun);
-        else
-            allVolumes = currentRun;
-        end
-        jobs{subj}.spm.stats.fmri_spec.sess(run).scans = allVolumes; %#ok<*AGROW>
-        jobs{subj}.spm.stats.fmri_spec.sess(run).cond = struct('name', {}, 'onset', {}, 'duration', {}, 'tmod', {}, 'pmod', {}, 'orth', {});
-        jobs{subj}.spm.stats.fmri_spec.sess(run).multi = {''};
-        if isstruct(onsets{1})
-            jobs{subj}.spm.stats.fmri_spec.sess(run).cond = onsets{run};
-        else
-            jobs{subj}.spm.stats.fmri_spec.sess(run).multi = fonset(run);
+        % Check of all TR are the same for each run
+        if ~isfield(par,'TR')
+            
+            jsons = get_subdir_regex_files( dirFonc{subj} , '^dic.*json$' );
+            if iscell(dirFonc{1})
+                assert( length(dirFonc{subj}) == length(jsons) , 'dic.*json were no found in all volumes' )
+            else
+                assert( length(dirFonc) == length(jsons) , 'dic.*json were no found in all volumes' )
+            end
+            % Multiple json files ? Like multi-echo ?
+            for j = 1 : length(jsons)
+                jsons{j} = jsons{j}(1,:); % only keep the first echo
+            end
+            [ TRs ] = get_string_from_json( jsons , 'RepetitionTime' , 'numeric' );
+            allTR = nan(size(TRs));
+            for idx = 1 : length(allTR)
+                allTR(idx) = TRs{idx}{1};
+            end
+            if iscell(dirFonc{1})
+                assert( all( allTR(1)==allTR ) , 'TR is not the same for each run : %s' , dirFonc{subj}{:} )
+            else
+                assert( all( allTR(1)==allTR ) , 'TR is not the same for each run : %s' , dirFonc{:} )
+            end
+            
+            % Define TR
+            par.TR = allTR(1)/1000; % convert milliseconds into seconds
+            
         end
         
+        %     if iscell(dirFonc{1})
+        subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg);
+        unzip_volume(subjectRuns);
+        subjectRuns = get_subdir_regex_files(dirFonc{subj},par.file_reg,struct('verbose',0));
         if par.rp
-            jobs{subj}.spm.stats.fmri_spec.sess(run).multi_reg = fileRP(run);
-        else
-            jobs{subj}.spm.stats.fmri_spec.sess(run).multi_reg = {''};
+            fileRP = get_subdir_regex_files(dirFonc{subj},par.rp_regex);
+        end
+        %     else
+        %         subjectRuns = dirFonc;
+        %     end
+        
+        % When onsets are inside the .mat file
+        if ~ isstruct(onsets{1})
+            fonset = cellstr(char(onsets(subj)));
         end
         
-        jobs{subj}.spm.stats.fmri_spec.sess(run).regress = struct('name', {}, 'val', {});
-        jobs{subj}.spm.stats.fmri_spec.sess(run).hpf = 128;
+        for run = 1:length(subjectRuns)
+            currentRun = cellstr(subjectRuns{run}) ;
+            clear allVolumes
+            
+            if length(currentRun) == 1 %4D file
+                allVolumes = spm_select('expand',currentRun);
+            else
+                allVolumes = currentRun;
+            end
+            jobs{subj}.spm.stats.fmri_spec.sess(run).scans = allVolumes; %#ok<*AGROW>
+            jobs{subj}.spm.stats.fmri_spec.sess(run).cond = struct('name', {}, 'onset', {}, 'duration', {}, 'tmod', {}, 'pmod', {}, 'orth', {});
+            jobs{subj}.spm.stats.fmri_spec.sess(run).multi = {''};
+            if isstruct(onsets{1})
+                jobs{subj}.spm.stats.fmri_spec.sess(run).cond = onsets{run};
+            else
+                jobs{subj}.spm.stats.fmri_spec.sess(run).multi = fonset(run);
+            end
+            
+            if par.rp
+                jobs{subj}.spm.stats.fmri_spec.sess(run).multi_reg = fileRP(run);
+            else
+                jobs{subj}.spm.stats.fmri_spec.sess(run).multi_reg = {''};
+            end
+            
+            jobs{subj}.spm.stats.fmri_spec.sess(run).regress = struct('name', {}, 'val', {});
+            jobs{subj}.spm.stats.fmri_spec.sess(run).hpf = 128;
+            
+        end % run
         
-    end
+        jobs{subj}.spm.stats.fmri_spec.timing.units = 'secs';
+        jobs{subj}.spm.stats.fmri_spec.timing.RT = par.TR;
+        jobs{subj}.spm.stats.fmri_spec.timing.fmri_t = 16;
+        jobs{subj}.spm.stats.fmri_spec.timing.fmri_t0 = 8;
+        
+        jobs{subj}.spm.stats.fmri_spec.fact = struct('name', {}, 'levels', {});
+        jobs{subj}.spm.stats.fmri_spec.bases.hrf.derivs = [0 0];
+        jobs{subj}.spm.stats.fmri_spec.volt = 1;
+        jobs{subj}.spm.stats.fmri_spec.global = 'None';
+        jobs{subj}.spm.stats.fmri_spec.mthresh = par.mask_thr;
+        jobs{subj}.spm.stats.fmri_spec.mask = {''};
+        jobs{subj}.spm.stats.fmri_spec.cvi = par.cvi;
+        
+    end % SPM.mat exists ?
     
     jobs{subj}.spm.stats.fmri_spec.dir = dirStats(subj);
-    jobs{subj}.spm.stats.fmri_spec.timing.units = 'secs';
-    jobs{subj}.spm.stats.fmri_spec.timing.RT = par.TR;
-    jobs{subj}.spm.stats.fmri_spec.timing.fmri_t = 16;
-    jobs{subj}.spm.stats.fmri_spec.timing.fmri_t0 = 8;
-    
-    
-    
-    jobs{subj}.spm.stats.fmri_spec.fact = struct('name', {}, 'levels', {});
-    jobs{subj}.spm.stats.fmri_spec.bases.hrf.derivs = [0 0];
-    jobs{subj}.spm.stats.fmri_spec.volt = 1;
-    jobs{subj}.spm.stats.fmri_spec.global = 'None';
-    jobs{subj}.spm.stats.fmri_spec.mthresh = par.mask_thr;
-    jobs{subj}.spm.stats.fmri_spec.mask = {''};
-    jobs{subj}.spm.stats.fmri_spec.cvi = par.cvi;
-    
     
 end
 
 
 %% Other routines
 
-[ jobs ] = job_ending_rountines( jobs, [], par );
+[ jobs ] = job_ending_rountines( jobs, skip, par );
 
 
 end % function

--- a/SPM/preproc/do_topup_unwarp_4D.m
+++ b/SPM/preproc/do_topup_unwarp_4D.m
@@ -46,6 +46,10 @@ defpar.auto_add_obj = 1;
 
 par = complet_struct(par,defpar);
 
+% Security
+if par.sge
+    par.auto_add_obj = 0;
+end
 
 parsge  = par.sge;
 par.sge = -1; % only prepare commands

--- a/SPM/preproc/do_topup_unwarp_4D.m
+++ b/SPM/preproc/do_topup_unwarp_4D.m
@@ -61,7 +61,11 @@ fprintf('\n')
 for subj=1:nrSubject
     
     % Extract subject name, and print it
-    subjectName = get_parent_path(in{subj}(1));
+    if obj
+        subjectName = get_parent_path(get_parent_path(in{subj}(1)));
+    else
+        subjectName = get_parent_path(in{subj}(1));
+    end
     
     % Echo in terminal & initialize job_subj
     fprintf('[%s]: Preparing JOB %d/%d for %s \n', mfilename, subj, nrSubject, subjectName{1});

--- a/SPM/preproc/do_topup_unwarp_4D.m
+++ b/SPM/preproc/do_topup_unwarp_4D.m
@@ -1,4 +1,4 @@
-function job = do_topup_unwarp_4D(dirFonc,par)
+function job = do_topup_unwarp_4D(in,par)
 % DO_TOPUP_UNWARP_4D - FSL:topup - FSL:unwarp
 % img is multilevel directory (see get_subdir_regex).
 % The function will generate a mean for each runs (necessary to do topup on
@@ -14,6 +14,14 @@ if ~exist('par','var')
 end
 
 
+obj = 0;
+if isa(in,'volume')
+    obj = 1;
+    in_obj  = in;
+    in = in_obj.toJob(1);
+end
+
+
 %% defpar
 
 defpar.todo               = 0;
@@ -21,9 +29,12 @@ defpar.subdir             = 'topup';
 defpar.file_reg           = '^f.*nii';
 defpar.fsl_output_format  = 'NIFTI';
 defpar.do_apply           = [];
+
 defpar.redo               = 0;
 defpar.pct                = 0;
 defpar.verbose            = 1;
+
+defpar.auto_add_obj = 1;
 
 par = complet_struct(par,defpar);
 
@@ -37,8 +48,8 @@ par.verbose = 0; % don't print anything yet
 
 %%  FSL:topup - FSL:unwarp
 
-if iscell(dirFonc{1})
-    nrSubject = length(dirFonc);
+if iscell(in{1})
+    nrSubject = length(in);
 else
     nrSubject = 1;
 end
@@ -50,14 +61,20 @@ fprintf('\n')
 for subj=1:nrSubject
     
     % Extract subject name, and print it
-    subjectName = get_parent_path(dirFonc{subj}(1));
+    subjectName = get_parent_path(in{subj}(1));
     
     % Echo in terminal & initialize job_subj
     fprintf('[%s]: Preparing JOB %d/%d for %s \n', mfilename, subj, nrSubject, subjectName{1});
     job_subj = {sprintf('#################### JOB %d/%d for %s #################### \n', subj, nrSubject, subjectName{1})}; % initialize
     
-    % Fetch current subject images files
-    runList = get_subdir_regex_files(dirFonc{subj},par.file_reg,1);
+    if obj
+        % Fetch current subject images files
+        runList = in_obj(subj,:).getPath';
+    else
+        % Fetch current subject images files
+        runList = get_subdir_regex_files(in{subj},par.file_reg,1);
+    end
+    
     
     % Create inside the subject dir runName "topup" dire, which will be our
     % working directory
@@ -141,10 +158,39 @@ for subj=1:nrSubject
     
 end % for - subject
 
+
+%% Executes th prepared commands
+
 par.sge     = parsge;
 par.verbose = parverbose;
 
 job = do_cmd_sge(job,par);
+
+
+%% Add outputs objects
+
+if obj && par.auto_add_obj
+    
+    serieArray      = [in_obj.serie];
+    tag             =  in_obj(1).tag;
+    
+    switch defpar.fsl_output_format
+        case 'NIFTI'
+            ext = '.*.nii';
+        case 'NIFTI_GZ'
+            ext = '.*.nii.gz';
+    end
+    
+    serieArray.addVolume([ '^ut'     tag ext],[ 'ut'     tag])
+    
+    if strcmp(tag(1),'r')
+        tag = tag(2:end);
+    end
+    
+    serieArray.addVolume([ '^mean'   tag ext],[ 'mean'   tag])
+    serieArray.addVolume([ '^utmean' tag ext],[ 'utmean' tag])
+    
+end
 
 
 end % function

--- a/SPM/preproc/do_topup_unwarp_4D.m
+++ b/SPM/preproc/do_topup_unwarp_4D.m
@@ -1,11 +1,15 @@
 function job = do_topup_unwarp_4D(in,par)
 % DO_TOPUP_UNWARP_4D - FSL:topup - FSL:unwarp
+%
+% INPUT : in can be 'char' of dir, multi-level 'cellstr' of dir, '@volume' array
+%
 % img is multilevel directory (see get_subdir_regex).
 % The function will generate a mean for each runs (necessary to do topup on
 % each run), then compute the warpfield, and finaly apply the warpfield to
 % each run files (volumes + mean, normal scans + reversed phase scans).
 
-% See also get_subdir_regex job_realign
+% See also get_subdir_regex job_realign exam exam.AddSerie exam.addVolume
+
 
 %% Check input arguments
 
@@ -13,6 +17,10 @@ if ~exist('par','var')
     par = ''; % for defpar
 end
 
+if nargin < 1
+    help(mfilename)
+    error('[%s]: not enough input arguments - in is required',mfilename)
+end
 
 obj = 0;
 if isa(in,'volume')
@@ -185,14 +193,14 @@ if obj && par.auto_add_obj
             ext = '.*.nii.gz';
     end
     
-    serieArray.addVolume([ '^ut'     tag ext],[ 'ut'     tag])
+    serieArray.addVolume(['^ut'     tag ext],['ut'     tag])
     
     if strcmp(tag(1),'r')
         tag = tag(2:end);
     end
     
-    serieArray.addVolume([ '^mean'   tag ext],[ 'mean'   tag])
-    serieArray.addVolume([ '^utmean' tag ext],[ 'utmean' tag])
+    serieArray.addVolume(['^mean'   tag ext],['mean'   tag])
+    serieArray.addVolume(['^utmean' tag ext],['utmean' tag])
     
 end
 

--- a/SPM/preproc/job_apply_normalize.m
+++ b/SPM/preproc/job_apply_normalize.m
@@ -102,9 +102,9 @@ end
 if obj && par.auto_add_obj
     
     serieArray = [in_obj.serie];
-    prefix = in_obj(1).tag;
+    tag        =  in_obj(1).tag;
     
-    serieArray.addVolume([ '^w' prefix],[ 'w' prefix])
+    serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
     
 end
 

--- a/SPM/preproc/job_apply_normalize.m
+++ b/SPM/preproc/job_apply_normalize.m
@@ -104,8 +104,9 @@ if obj && par.auto_add_obj
     
     serieArray = [in_obj.serie];
     tag        =  in_obj(1).tag;
+    ext        = '.*.nii$';
     
-    serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
+    serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
     
 end
 

--- a/SPM/preproc/job_apply_normalize.m
+++ b/SPM/preproc/job_apply_normalize.m
@@ -21,8 +21,9 @@ end
 obj = 0;
 if isa(img,'volume')
     obj = 1;
-    in_obj  = img;
-    img = in_obj.toJob;
+    in_obj = img;
+    img    = in_obj.toJob;
+    warp_field = warp_field.toJob;
 elseif ischar(img) || iscellstr(img)
     % Ensure the inputs are cellstrings, to avoid dimensions problems
     img = cellstr(img)';

--- a/SPM/preproc/job_apply_normalize.m
+++ b/SPM/preproc/job_apply_normalize.m
@@ -1,11 +1,13 @@
 function jobs = job_apply_normalize(warp_field,img, par)
 % JOB_APPLY_NORMALIZE - SPM:Spatial:Normalise:Write
 %
+% INPUT : warp_field & img can be 'char' of volume(file), single-level 'cellstr' of volume(file), '@volume' array
+%
 % for spm12 warp_field, is indeed the flow field y_*.nii or iy_*.nii
 %
 % To build the image list easily, use get_subdir_regex & get_subdir_regex_files
 %
-% See also job_do_segment get_subdir_regex get_subdir_regex_files
+% See also job_do_segment get_subdir_regex get_subdir_regex_files exam exam.AddSerie exam.addVolume
 
 
 %% Check input arguments
@@ -14,7 +16,8 @@ if ~exist('par','var')
     par = ''; % for defpar
 end
 
-if nargin < 2
+if nargin < 1
+    help(mfilename)
     error('[%s]: not enough input arguments - warp_filed & imagelist are required',mfilename)
 end
 
@@ -106,7 +109,7 @@ if obj && par.auto_add_obj
     tag        =  in_obj(1).tag;
     ext        = '.*.nii$';
     
-    serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
+    serieArray.addVolume(['^' par.prefix tag ext],[par.prefix tag])
     
 end
 

--- a/SPM/preproc/job_apply_normalize.m
+++ b/SPM/preproc/job_apply_normalize.m
@@ -55,6 +55,11 @@ defpar.auto_add_obj = 1;
 
 par = complet_struct(par,defpar);
 
+% Security
+if par.sge
+    par.auto_add_obj = 0;
+end
+
 
 %% SPM:Spatial:Normalise:Write
 

--- a/SPM/preproc/job_apply_normalize.m
+++ b/SPM/preproc/job_apply_normalize.m
@@ -18,6 +18,18 @@ if nargin < 2
     error('[%s]: not enough input arguments - warp_filed & imagelist are required',mfilename)
 end
 
+obj = 0;
+if isa(img,'volume')
+    obj = 1;
+    in_obj  = img;
+    img = in_obj.toJob;
+elseif ischar(img) || iscellstr(img)
+    % Ensure the inputs are cellstrings, to avoid dimensions problems
+    img = cellstr(img)';
+else
+    error('[%s]: wrong input format (cellstr, char, @volume)', mfilename)
+end
+
 
 %% defpar
 
@@ -34,6 +46,8 @@ defpar.sge     = 0;
 defpar.run     = 0;
 defpar.display = 0;
 defpar.jobname = 'spm_apply_norm';
+
+defpar.auto_add_obj = 1;
 
 par = complet_struct(par,defpar);
 
@@ -81,6 +95,18 @@ end
 %% Other routines
 
 [ jobs ] = job_ending_rountines( jobs, skip, par );
+
+
+%% Add outputs objects
+
+if obj && par.auto_add_obj
+    
+    serieArray = [in_obj.serie];
+    prefix = in_obj(1).tag;
+    
+    serieArray.addVolume([ '^w' prefix],[ 'w' prefix])
+    
+end
 
 
 end % function

--- a/SPM/preproc/job_coregister.m
+++ b/SPM/preproc/job_coregister.m
@@ -65,6 +65,11 @@ defpar.walltime = '00:30:00';
 
 par = complet_struct(par,defpar);
 
+% Security
+if par.sge
+    par.auto_add_obj = 0;
+end
+
 
 %% SPM:Spatial:Coregister
 

--- a/SPM/preproc/job_coregister.m
+++ b/SPM/preproc/job_coregister.m
@@ -1,9 +1,16 @@
 function jobs = job_coregister(src,ref,other,par)
 % JOB_COREGISTER - SPM:Spatial:Coregister
 %
+% INPUT : src - ref can be 'char' of volume(file), single-level 'cellstr' of volume(file), '@volume' array
+%             other can be 'char' of volume(file),  multi-level 'cellstr' of volume(file), '@volume' array
+%
+% ref   -> remains static, it's the target
+% src   -> will be moved to match the 'ref', this transformation will be used on 'other'
+% other -> the transformation "src->ref" will be applied on 'other' images
+%
 % To build the image list easily, use get_subdir_regex & get_subdir_regex_files
 %
-% See also get_subdir_regex get_subdir_regex_files
+% See also get_subdir_regex get_subdir_regex_files exam exam.AddSerie exam.addVolume
 
 
 %% Check input arguments
@@ -15,6 +22,10 @@ if ~exist('par','var')
     par = ''; % for defpar
 end
 
+if nargin < 1
+    help(mfilename)
+    error('[%s]: not enough input arguments - at least src & ref are required',mfilename)
+end
 
 obj = 0;
 if isa(src,'volume')
@@ -172,9 +183,9 @@ if obj && par.auto_add_obj
         case 'estimate'
             % pass, no volume created
         case 'estimate_and_write'
-            serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
+            serieArray.addVolume(['^' par.prefix tag ext],[par.prefix tag])
         case 'write'
-            serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
+            serieArray.addVolume(['^' par.prefix tag ext],[par.prefix tag])
     end
     
     if ~isempty(other)
@@ -183,9 +194,9 @@ if obj && par.auto_add_obj
             case 'estimate'
                 % pass, no volume created
             case 'estimate_and_write'
-                serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
+                serieArray.addVolume(['^' par.prefix tag ext],[par.prefix tag])
             case 'write'
-                serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
+                serieArray.addVolume(['^' par.prefix tag ext],[par.prefix tag])
         end
         
     end

--- a/SPM/preproc/job_coregister.m
+++ b/SPM/preproc/job_coregister.m
@@ -129,31 +129,35 @@ end
 %% Special routine for coregistration with matvol
 % Write a matvol_coregistration_info.txt file to remember it has been done, and allow sckipping the next tine
 
-for j = 1:length(jobs)
+if par.run % not for display
     
-    % Content of the file
-    str = gencode(jobs{j}); % generate matlabbatch code
-    %field job coreg can either be in estimate or estwrite
-    if isfield(jobs{j}.spm.spatial.coreg,'estimate')
-        jobcoreg = jobs{j}.spm.spatial.coreg.estimate;
-    elseif isfield(jobs{j}.spm.spatial.coreg,'estwrite')
-        jobcoreg = jobs{j}.spm.spatial.coreg.estwrite;
-    elseif isfield(jobs{j}.spm.spatial.coreg,'write')
-        jobcoreg = jobs{j}.spm.spatial.coreg.write;
-    end
-    
-    % Source : Where to write the file ?
-    upper_dir_path_source = get_parent_path(char(jobcoreg.source));
-    coreg_file_source     = fullfile(upper_dir_path_source,'matvol_coregistration_info.txt');
-    write_in_text_file(coreg_file_source, str)
-    
-    % Other : Where to write the file ?
-    if isfield(jobcoreg,'other')
-        for o = 1:length(jobcoreg.other)
-            upper_dir_path_other = get_parent_path(char(jobcoreg.other{o}));
-            coreg_file_other     = fullfile(upper_dir_path_other,'matvol_coregistration_info.txt');
-            write_in_text_file(coreg_file_other, str)
+    for j = 1:length(jobs)
+        
+        % Content of the file
+        str = gencode(jobs{j}); % generate matlabbatch code
+        %field job coreg can either be in estimate or estwrite
+        if isfield(jobs{j}.spm.spatial.coreg,'estimate')
+            jobcoreg = jobs{j}.spm.spatial.coreg.estimate;
+        elseif isfield(jobs{j}.spm.spatial.coreg,'estwrite')
+            jobcoreg = jobs{j}.spm.spatial.coreg.estwrite;
+        elseif isfield(jobs{j}.spm.spatial.coreg,'write')
+            jobcoreg = jobs{j}.spm.spatial.coreg.write;
         end
+        
+        % Source : Where to write the file ?
+        upper_dir_path_source = get_parent_path(char(jobcoreg.source));
+        coreg_file_source     = fullfile(upper_dir_path_source,'matvol_coregistration_info.txt');
+        write_in_text_file(coreg_file_source, str)
+        
+        % Other : Where to write the file ?
+        if isfield(jobcoreg,'other')
+            for o = 1:length(jobcoreg.other)
+                upper_dir_path_other = get_parent_path(char(jobcoreg.other{o}));
+                coreg_file_other     = fullfile(upper_dir_path_other,'matvol_coregistration_info.txt');
+                write_in_text_file(coreg_file_other, str)
+            end
+        end
+        
     end
     
 end

--- a/SPM/preproc/job_coregister.m
+++ b/SPM/preproc/job_coregister.m
@@ -169,28 +169,26 @@ if obj && par.auto_add_obj
     
     serieArray = [src_obj.serie];
     tag        =  src_obj(1).tag;
+    ext        = '.*.nii$';
     
     switch par.type
         case 'estimate'
             % pass, no volume created
         case 'estimate_and_write'
-            serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
+            serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
         case 'write'
-            serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
+            serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
     end
     
     if ~isempty(other)
-        
-        serieArray = [other_obj.serie];
-        tag        =  other_obj(1).tag;
         
         switch par.type
             case 'estimate'
                 % pass, no volume created
             case 'estimate_and_write'
-                serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
+                serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
             case 'write'
-                serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
+                serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
         end
         
     end

--- a/SPM/preproc/job_do_segment.m
+++ b/SPM/preproc/job_do_segment.m
@@ -32,9 +32,6 @@ obj = 0;
 if isa(img,'volume')
     obj = 1;
     in_obj  = img;
-    contains_gz = ~cellfun(@isempty,strfind(in_obj.getPath,'.nii.gz'));
-    assert( ~any(contains_gz(:)), 'Volumes must be unzip first. Use examArray.unzipVolume(par) or volumeArray.unzip(par).')
-    img = in_obj.toJob;
 elseif ischar(img) || iscellstr(img)
     % Ensure the inputs are cellstrings, to avoid dimensions problems
     img = cellstr(img)';
@@ -64,11 +61,17 @@ defpar.walltime = '01:00:00';
 
 par = complet_struct(par,defpar);
 
+% Security
+if par.sge
+    par.auto_add_obj = 0;
+end
+
 
 %% Unzip : unzip volumes if required
 
 if obj
-    % pass
+    in_obj.unzip(par);
+    img = in_obj.toJob;
 else
     img = unzip_volume(img); % it makes the multi structure down ... arg <============ need to solve this
 end

--- a/SPM/preproc/job_do_segment.m
+++ b/SPM/preproc/job_do_segment.m
@@ -159,33 +159,33 @@ end
 if obj && par.auto_add_obj
     
     serieArray = [in_obj.serie];
-    prefix = in_obj(1).tag;
+    tag        =  in_obj(1).tag;
     
     % Warp field
-    if par.warp(2), serieArray.addVolume([ '^y_' prefix],[ 'y_' prefix] ,1), end % Forward
-    if par.warp(1), serieArray.addVolume(['^iy_' prefix],['iy_' prefix],1), end % Inverse
+    if par.warp(2), serieArray.addVolume([ '^y_' tag],[ 'y_' tag] ,1), end % Forward
+    if par.warp(1), serieArray.addVolume(['^iy_' tag],['iy_' tag],1), end % Inverse
     
     % Bias field
-    if par.bias(2), serieArray.addVolume(['^m'          prefix],['m'          prefix],1), end % Corrected
-    if par.bias(1), serieArray.addVolume(['^BiasField_' prefix],['BiasField_' prefix],1), end % Field
+    if par.bias(2), serieArray.addVolume(['^m'          tag],['m'          tag],1), end % Corrected
+    if par.bias(1), serieArray.addVolume(['^BiasField_' tag],['BiasField_' tag],1), end % Field
     
     % GM
-    if par.GM (3), serieArray.addVolume([  '^c1' prefix],[  'c1' prefix]), end % native_space(c*)
-    if par.GM (4), serieArray.addVolume([ '^rc1' prefix],[ 'rc1' prefix]), end % native_space_dartel_import(rc*)
-    if par.GM (1), serieArray.addVolume([ '^wc1' prefix],[ 'wc1' prefix]), end % warped_space_Unmodulated(wc*)
-    if par.GM (2), serieArray.addVolume(['^mwc1' prefix],['mwc1' prefix]), end % warped_space_modulated(mwc*)
+    if par.GM (3), serieArray.addVolume([  '^c1' tag],[  'c1' tag]), end % native_space(c*)
+    if par.GM (4), serieArray.addVolume([ '^rc1' tag],[ 'rc1' tag]), end % native_space_dartel_import(rc*)
+    if par.GM (1), serieArray.addVolume([ '^wc1' tag],[ 'wc1' tag]), end % warped_space_Unmodulated(wc*)
+    if par.GM (2), serieArray.addVolume(['^mwc1' tag],['mwc1' tag]), end % warped_space_modulated(mwc*)
     
     % WM
-    if par.WM (3), serieArray.addVolume([  '^c2' prefix],[  'c2' prefix]), end % native_space(c*)
-    if par.WM (4), serieArray.addVolume([ '^rc2' prefix],[ 'rc2' prefix]), end % native_space_dartel_import(rc*)
-    if par.WM (1), serieArray.addVolume([ '^wc2' prefix],[ 'wc2' prefix]), end % warped_space_Unmodulated(wc*)
-    if par.WM (2), serieArray.addVolume(['^mwc2' prefix],['mwc2' prefix]), end % warped_space_modulated(mwc*)
+    if par.WM (3), serieArray.addVolume([  '^c2' tag],[  'c2' tag]), end % native_space(c*)
+    if par.WM (4), serieArray.addVolume([ '^rc2' tag],[ 'rc2' tag]), end % native_space_dartel_import(rc*)
+    if par.WM (1), serieArray.addVolume([ '^wc2' tag],[ 'wc2' tag]), end % warped_space_Unmodulated(wc*)
+    if par.WM (2), serieArray.addVolume(['^mwc2' tag],['mwc2' tag]), end % warped_space_modulated(mwc*)
     
     % CSF
-    if par.CSF(3), serieArray.addVolume([  '^c3' prefix],[  'c3' prefix]), end % native_space(c*)
-    if par.CSF(4), serieArray.addVolume([ '^rc3' prefix],[ 'rc3' prefix]), end % native_space_dartel_import(rc*)
-    if par.CSF(1), serieArray.addVolume([ '^wc3' prefix],[ 'wc3' prefix]), end % warped_space_Unmodulated(wc*)
-    if par.CSF(2), serieArray.addVolume(['^mwc3' prefix],['mwc3' prefix]), end % warped_space_modulated(mwc*)
+    if par.CSF(3), serieArray.addVolume([  '^c3' tag],[  'c3' tag]), end % native_space(c*)
+    if par.CSF(4), serieArray.addVolume([ '^rc3' tag],[ 'rc3' tag]), end % native_space_dartel_import(rc*)
+    if par.CSF(1), serieArray.addVolume([ '^wc3' tag],[ 'wc3' tag]), end % warped_space_Unmodulated(wc*)
+    if par.CSF(2), serieArray.addVolume(['^mwc3' tag],['mwc3' tag]), end % warped_space_modulated(mwc*)
     
 end
 

--- a/SPM/preproc/job_do_segment.m
+++ b/SPM/preproc/job_do_segment.m
@@ -28,6 +28,8 @@ obj = 0;
 if isa(img,'volume')
     obj = 1;
     in_obj  = img;
+    contains_gz = ~cellfun(@isempty,strfind(in_obj.getPath,'.nii.gz'));
+    assert( ~any(contains_gz(:)), 'Volumes must be unzip first. Use examArray.unzipVolume(par) or volumeArray.unzip(par).')
     img = in_obj.toJob;
 elseif ischar(img) || iscellstr(img)
     % Ensure the inputs are cellstrings, to avoid dimensions problems
@@ -61,7 +63,11 @@ par = complet_struct(par,defpar);
 
 %% Unzip : unzip volumes if required
 
-img = unzip_volume(img); % it makes the multi structure down ... arg <============ need to solve this
+if obj
+    % pass
+else
+    img = unzip_volume(img); % it makes the multi structure down ... arg <============ need to solve this
+end
 
 
 %% SPM:Spatial:Segment

--- a/SPM/preproc/job_do_segment.m
+++ b/SPM/preproc/job_do_segment.m
@@ -1,6 +1,8 @@
 function  jobs = job_do_segment(img,par)
 % JOB_DO_SEGMENT - SPM:Spatial:Segment
 %
+% INPUT : img can be 'char' of volume(file), single-level 'cellstr' of volume(file), '@volume' array
+%
 % To build the image list easily, use get_subdir_regex & get_subdir_regex_files
 %
 % for spm12 segment, if img{1} has several line then it is a multichannel
@@ -12,7 +14,7 @@ function  jobs = job_do_segment(img,par)
 %   par.bias = [0 1]; % bias field / bias corrected image
 %   par.warp = [1 1]; % warp field native->template / warp field native<-template
 %
-% See also get_subdir_regex get_subdir_regex_files
+% See also get_subdir_regex get_subdir_regex_files exam exam.AddSerie exam.addVolume
 
 
 %% Check input arguments
@@ -22,6 +24,7 @@ if ~exist('par','var')
 end
 
 if nargin < 1
+    help(mfilename)
     error('[%s]: not enough input arguments - image list is required',mfilename)
 end
 

--- a/SPM/preproc/job_do_segment.m
+++ b/SPM/preproc/job_do_segment.m
@@ -6,10 +6,11 @@ function  jobs = job_do_segment(img,par)
 % for spm12 segment, if img{1} has several line then it is a multichannel
 %
 % 'par' allow you to specify which output to save  defaults are
-%   par.GM   = [0 0 1 0]; % Unmodulated / modulated / native_space dartel / import
+%   par.GM   = [0 0 1 0]; % warped_space_Unmodulated(wc*) / warped_space_modulated(mwc*) / native_space(c*) / native_space_dartel_import(rc*)
 %   par.WM   = [0 0 1 0];
 %   par.CSF  = [0 0 1 0];
 %   par.bias = [0 1]; % bias field / bias corrected image
+%   par.warp = [1 1]; % warp field native->template / warp field native<-template
 %
 % See also get_subdir_regex get_subdir_regex_files
 

--- a/SPM/preproc/job_do_segment.m
+++ b/SPM/preproc/job_do_segment.m
@@ -168,7 +168,7 @@ if obj && par.auto_add_obj
     tag        =  in_obj(1).tag;
     
     % Warp field
-    if par.warp(2), serieArray.addVolume([ '^y_' tag],[ 'y_' tag] ,1), end % Forward
+    if par.warp(2), serieArray.addVolume([ '^y_' tag],[ 'y_' tag],1), end % Forward
     if par.warp(1), serieArray.addVolume(['^iy_' tag],['iy_' tag],1), end % Inverse
     
     % Bias field

--- a/SPM/preproc/job_do_segment.m
+++ b/SPM/preproc/job_do_segment.m
@@ -166,32 +166,33 @@ if obj && par.auto_add_obj
     
     serieArray = [in_obj.serie];
     tag        =  in_obj(1).tag;
+    ext        = '.*.nii$';
     
     % Warp field
-    if par.warp(2), serieArray.addVolume([ '^y_' tag],[ 'y_' tag],1), end % Forward
-    if par.warp(1), serieArray.addVolume(['^iy_' tag],['iy_' tag],1), end % Inverse
+    if par.warp(2), serieArray.addVolume([ '^y_' tag ext],[ 'y_' tag],1), end % Forward
+    if par.warp(1), serieArray.addVolume(['^iy_' tag ext],['iy_' tag],1), end % Inverse
     
     % Bias field
-    if par.bias(2), serieArray.addVolume(['^m'          tag],['m'          tag],1), end % Corrected
-    if par.bias(1), serieArray.addVolume(['^BiasField_' tag],['BiasField_' tag],1), end % Field
+    if par.bias(2), serieArray.addVolume(['^m'          tag ext],['m'          tag],1), end % Corrected
+    if par.bias(1), serieArray.addVolume(['^BiasField_' tag ext],['BiasField_' tag],1), end % Field
     
     % GM
-    if par.GM (3), serieArray.addVolume([  '^c1' tag],[  'c1' tag]), end % native_space(c*)
-    if par.GM (4), serieArray.addVolume([ '^rc1' tag],[ 'rc1' tag]), end % native_space_dartel_import(rc*)
-    if par.GM (1), serieArray.addVolume([ '^wc1' tag],[ 'wc1' tag]), end % warped_space_Unmodulated(wc*)
-    if par.GM (2), serieArray.addVolume(['^mwc1' tag],['mwc1' tag]), end % warped_space_modulated(mwc*)
+    if par.GM (3), serieArray.addVolume([  '^c1' tag ext],[  'c1' tag]), end % native_space(c*)
+    if par.GM (4), serieArray.addVolume([ '^rc1' tag ext],[ 'rc1' tag]), end % native_space_dartel_import(rc*)
+    if par.GM (1), serieArray.addVolume([ '^wc1' tag ext],[ 'wc1' tag]), end % warped_space_Unmodulated(wc*)
+    if par.GM (2), serieArray.addVolume(['^mwc1' tag ext],['mwc1' tag]), end % warped_space_modulated(mwc*)
     
     % WM
-    if par.WM (3), serieArray.addVolume([  '^c2' tag],[  'c2' tag]), end % native_space(c*)
-    if par.WM (4), serieArray.addVolume([ '^rc2' tag],[ 'rc2' tag]), end % native_space_dartel_import(rc*)
-    if par.WM (1), serieArray.addVolume([ '^wc2' tag],[ 'wc2' tag]), end % warped_space_Unmodulated(wc*)
-    if par.WM (2), serieArray.addVolume(['^mwc2' tag],['mwc2' tag]), end % warped_space_modulated(mwc*)
+    if par.WM (3), serieArray.addVolume([  '^c2' tag ext],[  'c2' tag]), end % native_space(c*)
+    if par.WM (4), serieArray.addVolume([ '^rc2' tag ext],[ 'rc2' tag]), end % native_space_dartel_import(rc*)
+    if par.WM (1), serieArray.addVolume([ '^wc2' tag ext],[ 'wc2' tag]), end % warped_space_Unmodulated(wc*)
+    if par.WM (2), serieArray.addVolume(['^mwc2' tag ext],['mwc2' tag]), end % warped_space_modulated(mwc*)
     
     % CSF
-    if par.CSF(3), serieArray.addVolume([  '^c3' tag],[  'c3' tag]), end % native_space(c*)
-    if par.CSF(4), serieArray.addVolume([ '^rc3' tag],[ 'rc3' tag]), end % native_space_dartel_import(rc*)
-    if par.CSF(1), serieArray.addVolume([ '^wc3' tag],[ 'wc3' tag]), end % warped_space_Unmodulated(wc*)
-    if par.CSF(2), serieArray.addVolume(['^mwc3' tag],['mwc3' tag]), end % warped_space_modulated(mwc*)
+    if par.CSF(3), serieArray.addVolume([  '^c3' tag ext],[  'c3' tag]), end % native_space(c*)
+    if par.CSF(4), serieArray.addVolume([ '^rc3' tag ext],[ 'rc3' tag]), end % native_space_dartel_import(rc*)
+    if par.CSF(1), serieArray.addVolume([ '^wc3' tag ext],[ 'wc3' tag]), end % warped_space_Unmodulated(wc*)
+    if par.CSF(2), serieArray.addVolume(['^mwc3' tag ext],['mwc3' tag]), end % warped_space_modulated(mwc*)
     
 end
 

--- a/SPM/preproc/job_do_segmentCAT12.m
+++ b/SPM/preproc/job_do_segmentCAT12.m
@@ -1,5 +1,7 @@
 function  jobs = job_do_segmentCAT12(img,par)
-%%  jobs = job_do_segmentCAT12(img,par)
+%
+% INPUT : img can be 'char' of volume(file), single-level 'cellstr' of volume(file), '@volume' array
+%
 % for spm12 segment, if img{1} has several line then it is a multichannel
 %
 % 'par' allow you to specify which output to save  defaults are
@@ -9,7 +11,7 @@ function  jobs = job_do_segmentCAT12(img,par)
 %   par.bias = [0 1]; % bias field / bias corrected image
 %   par.warp = [1 1]; % warp field native->template / warp field native<-template
 %
-% See also get_subdir_regex get_subdir_regex_files
+% See also get_subdir_regex get_subdir_regex_files exam exam.AddSerie exam.addVolume
 
 
 
@@ -24,8 +26,8 @@ if ~exist('par', 'var')
     par='';
 end
 
-
 if nargin < 1
+    help(mfilename)
     error('[%s]: not enough input arguments - image list is required',mfilename)
 end
 
@@ -176,7 +178,7 @@ if obj && par.auto_add_obj
     tag        =  in_obj(1).tag;
     ext        = '.*.nii$';
     
-    % Warp field (warp)
+    % Warp field
     if par.warp(2), serieArray.addVolume([ '^y_' tag ext],[ 'y_' tag],1), end % Forward
     if par.warp(1), serieArray.addVolume(['^iy_' tag ext],['iy_' tag],1), end % Inverse
     

--- a/SPM/preproc/job_do_segmentCAT12.m
+++ b/SPM/preproc/job_do_segmentCAT12.m
@@ -2,11 +2,15 @@ function  jobs = job_do_segmentCAT12(img,par)
 %%  jobs = job_do_segmentCAT12(img,par)
 % for spm12 segment, if img{1} has several line then it is a multichannel
 %
-% par allow you to specify which output to save  defaults are
-%   par.GM   = [0 0 1 0]; % Unmodulated / modulated / native_space dartel / import
+% 'par' allow you to specify which output to save  defaults are
+%   par.GM   = [0 0 1 0]; % warped_space_Unmodulated(wp*) / warped_space_modulated(mwp*) / native_space(p*) / native_space_dartel_import(rp*)
 %   par.WM   = [0 0 1 0];
 %   par.CSF  = [0 0 1 0];
 %   par.bias = [0 1]; % bias field / bias corrected image
+%   par.warp = [1 1]; % warp field native->template / warp field native<-template
+%
+% See also get_subdir_regex get_subdir_regex_files
+
 
 
 %% Check CAT12 toolbox install
@@ -42,14 +46,14 @@ end
 
 %% defpar
 
-defpar.GM        = [0 1 1 1]; % Unmodulated / modulated / native_space / dartel import
-% ??? first one not possible, but keep for compatibility with spm12 job_segment
-defpar.WM        = [0 1 1 1];
-defpar.CSF       = [0 1 1 1];
-defpar.bias      = [1 1 0] ;  % native normalize dartel     [0 1]; % bias field / bias corrected image
-defpar.def_field = [1 1];     % deformation field to write [y iy]
-defpar.jacobian  = 0;         % write jacobian determinant in normalize space
+% Retrocompatibility for SPM:Spatial:Segment options
+defpar.GM        = [0 0 1 0]; % warped_space_Unmodulated(wp*) / warped_space_modulated(mwp*) / native_space(p*) / native_space_dartel_import(rp*)
+defpar.WM        = [0 0 1 0];
+defpar.CSF       = [0 0 1 0];
+defpar.bias      = [0 1 0] ;  % native normalize dartel     [0 1]; % bias field / bias corrected image
+defpar.warp      = [1 1]; % warp field native->template / warp field native<-template
 
+defpar.jacobian  = 1;         % write jacobian determinant in normalize space
 defpar.doROI     = 1;
 defpar.doSurface = 1;
 defpar.subfolder = 0; % all results in the same subfolder
@@ -154,7 +158,7 @@ for nbsuj = 1:length(img)
     jobs{nbsuj}.spm.tools.cat.estwrite.output.jacobian.warped = par.jacobian;
     
     % Warp fields : y_ & iy_
-    jobs{nbsuj}.spm.tools.cat.estwrite.output.warps = par.def_field;
+    jobs{nbsuj}.spm.tools.cat.estwrite.output.warps = par.warp;
     
 end % for : nsubj
 
@@ -172,9 +176,9 @@ if obj && par.auto_add_obj
     tag        =  in_obj(1).tag;
     ext        = '.*.nii$';
     
-    % Warp field (def_field)
-    if par.def_field(2), serieArray.addVolume([ '^y_' tag ext],[ 'y_' tag],1), end % Forward
-    if par.def_field(1), serieArray.addVolume(['^iy_' tag ext],['iy_' tag],1), end % Inverse
+    % Warp field (warp)
+    if par.warp(2), serieArray.addVolume([ '^y_' tag ext],[ 'y_' tag],1), end % Forward
+    if par.warp(1), serieArray.addVolume(['^iy_' tag ext],['iy_' tag],1), end % Inverse
     
     % Bias field
     if par.bias(1), serieArray.addVolume([ '^m' tag ext],[ 'm' tag],1), end % Corrected

--- a/SPM/preproc/job_do_segmentCAT12.m
+++ b/SPM/preproc/job_do_segmentCAT12.m
@@ -170,32 +170,33 @@ if obj && par.auto_add_obj
     
     serieArray = [in_obj.serie];
     tag        =  in_obj(1).tag;
+    ext        = '.*.nii$';
     
     % Warp field (def_field)
-    if par.def_field(2), serieArray.addVolume([ '^y_' tag],[ 'y_' tag],1), end % Forward
-    if par.def_field(1), serieArray.addVolume(['^iy_' tag],['iy_' tag],1), end % Inverse
+    if par.def_field(2), serieArray.addVolume([ '^y_' tag ext],[ 'y_' tag],1), end % Forward
+    if par.def_field(1), serieArray.addVolume(['^iy_' tag ext],['iy_' tag],1), end % Inverse
     
     % Bias field
-    if par.bias(1), serieArray.addVolume([ '^m' tag],[ 'm' tag],1), end % Corrected
-    if par.bias(2), serieArray.addVolume(['^wm' tag],['wm' tag],1), end % Field
+    if par.bias(1), serieArray.addVolume([ '^m' tag ext],[ 'm' tag],1), end % Corrected
+    if par.bias(2), serieArray.addVolume(['^wm' tag ext],['wm' tag],1), end % Field
     
     % GM
-    if par.GM (3), serieArray.addVolume([  '^p1' tag],[  'p1' tag]), end % native_space(p*)
-    if par.GM (4), serieArray.addVolume([ '^rp1' tag],[ 'rp1' tag]), end % native_space_dartel_import(rp*)
-    if par.GM (1), serieArray.addVolume([ '^wp1' tag],[ 'wp1' tag]), end % warped_space_Unmodulated(wp*)
-    if par.GM (2), serieArray.addVolume(['^mwp1' tag],['mwp1' tag]), end % warped_space_modulated(mwp*)
+    if par.GM (3), serieArray.addVolume([  '^p1' tag ext],[  'p1' tag]), end % native_space(p*)
+    if par.GM (4), serieArray.addVolume([ '^rp1' tag ext],[ 'rp1' tag]), end % native_space_dartel_import(rp*)
+    if par.GM (1), serieArray.addVolume([ '^wp1' tag ext],[ 'wp1' tag]), end % warped_space_Unmodulated(wp*)
+    if par.GM (2), serieArray.addVolume(['^mwp1' tag ext],['mwp1' tag]), end % warped_space_modulated(mwp*)
     
     % WM
-    if par.WM (3), serieArray.addVolume([  '^p2' tag],[  'p2' tag]), end % native_space(p*)
-    if par.WM (4), serieArray.addVolume([ '^rp2' tag],[ 'rp2' tag]), end % native_space_dartel_import(rp*)
-    if par.WM (1), serieArray.addVolume([ '^wp2' tag],[ 'wp2' tag]), end % warped_space_Unmodulated(wp*)
-    if par.WM (2), serieArray.addVolume(['^mwp2' tag],['mwp2' tag]), end % warped_space_modulated(mwp*)
+    if par.WM (3), serieArray.addVolume([  '^p2' tag ext],[  'p2' tag]), end % native_space(p*)
+    if par.WM (4), serieArray.addVolume([ '^rp2' tag ext],[ 'rp2' tag]), end % native_space_dartel_import(rp*)
+    if par.WM (1), serieArray.addVolume([ '^wp2' tag ext],[ 'wp2' tag]), end % warped_space_Unmodulated(wp*)
+    if par.WM (2), serieArray.addVolume(['^mwp2' tag ext],['mwp2' tag]), end % warped_space_modulated(mwp*)
     
     % CSF
-    if par.CSF(3), serieArray.addVolume([  '^p3' tag],[  'p3' tag]), end % native_space(p*)
-    if par.CSF(4), serieArray.addVolume([ '^rp3' tag],[ 'rp3' tag]), end % native_space_dartel_import(rp*)
-    if par.CSF(1), serieArray.addVolume([ '^wp3' tag],[ 'wp3' tag]), end % warped_space_Unmodulated(wp*)
-    if par.CSF(2), serieArray.addVolume(['^mwp3' tag],['mwp3' tag]), end % warped_space_modulated(mwp*)
+    if par.CSF(3), serieArray.addVolume([  '^p3' tag ext],[  'p3' tag]), end % native_space(p*)
+    if par.CSF(4), serieArray.addVolume([ '^rp3' tag ext],[ 'rp3' tag]), end % native_space_dartel_import(rp*)
+    if par.CSF(1), serieArray.addVolume([ '^wp3' tag ext],[ 'wp3' tag]), end % warped_space_Unmodulated(wp*)
+    if par.CSF(2), serieArray.addVolume(['^mwp3' tag ext],['mwp3' tag]), end % warped_space_modulated(mwp*)
     
 end
 

--- a/SPM/preproc/job_do_segmentCAT12.m
+++ b/SPM/preproc/job_do_segmentCAT12.m
@@ -14,7 +14,6 @@ function  jobs = job_do_segmentCAT12(img,par)
 % See also get_subdir_regex get_subdir_regex_files exam exam.AddSerie exam.addVolume
 
 
-
 %% Check CAT12 toolbox install
 
 assert( ~isempty(which('cat12')), 'cat12.m not found you must install the toolbox')
@@ -35,9 +34,6 @@ obj = 0;
 if isa(img,'volume')
     obj = 1;
     in_obj  = img;
-    contains_gz = ~cellfun(@isempty,strfind(in_obj.getPath,'.nii.gz'));
-    assert( ~any(contains_gz(:)), 'Volumes must be unzip first. Use examArray.unzipVolume(par) or volumeArray.unzip(par).')
-    img = in_obj.toJob;
 elseif ischar(img) || iscellstr(img)
     % Ensure the inputs are cellstrings, to avoid dimensions problems
     img = cellstr(img)';
@@ -79,6 +75,11 @@ defpar.matlab_opt = ' -nodesktop ';
 
 par = complet_struct(par,defpar);
 
+% Security
+if par.sge
+    par.auto_add_obj = 0;
+end
+
 
 %% Prepare job generation
 
@@ -88,8 +89,10 @@ if cat.extopts.expertgui==0
     eval(par.cmd_prepend)
 end
 
+% unzip volumes if required
 if obj
-    %pass
+    in_obj.unzip(par);
+    img = in_obj.toJob;
 else
     if ~iscell(img)
         img = cellstr(img);

--- a/SPM/preproc/job_do_segmentCAT12.m
+++ b/SPM/preproc/job_do_segmentCAT12.m
@@ -52,7 +52,7 @@ end
 defpar.GM        = [0 0 1 0]; % warped_space_Unmodulated(wp*) / warped_space_modulated(mwp*) / native_space(p*) / native_space_dartel_import(rp*)
 defpar.WM        = [0 0 1 0];
 defpar.CSF       = [0 0 1 0];
-defpar.bias      = [0 1 0] ;  % native normalize dartel     [0 1]; % bias field / bias corrected image
+defpar.bias      = [1 1 0] ;  % native normalize dartel     [0 1]; % bias field / bias corrected image
 defpar.warp      = [1 1]; % warp field native->template / warp field native<-template
 
 defpar.jacobian  = 1;         % write jacobian determinant in normalize space

--- a/SPM/preproc/job_meica_afni.m
+++ b/SPM/preproc/job_meica_afni.m
@@ -308,13 +308,16 @@ for subj = 1 : nrSubject
         list_volume_src = addsuffixtofilenames(list_volume_src,ext_echo);      % add file extension
         list_volume_src{end+1} = sprintf('%s_%s',prefix,'ctab.txt');           % components table
         list_volume_src{end+1} = sprintf('meica.%s_e001',prefix);              % for motion paramters path (1/2)
+        list_volume_src{end+1} = sprintf('meica.%s_e001',prefix);              % for tsoc_nogs.nii (1/2)
         list_volume_src = addprefixtofilenames(list_volume_src,working_dir);
-        list_volume_src{end} = fullfile( list_volume_src{end} , 'motion.1D' ); % for motion paramters path (2/2)
+        list_volume_src{end-1} = fullfile( list_volume_src{end} , '/TED/tsoc_nogs.nii' ); % for motion paramters path (2/2)
+        list_volume_src{end  } = fullfile( list_volume_src{end} , 'motion.1D' ); % for motion paramters path (2/2)
         
         list_volume_dst = addprefixtofilenames(list_volume_base,prefix);       % add prefix
         list_volume_dst = addsuffixtofilenames(list_volume_dst,warp);          % add suffix for space
         list_volume_dst = addsuffixtofilenames(list_volume_dst,ext_echo);      % add file extension
         list_volume_dst{end+1} = sprintf('%s_%s',prefix,'ctab.txt');           % components table
+        list_volume_dst{end+1} = sprintf('%s_tsoc_nogs.nii',prefix);           % tsoc_nogs.nii : in case of TEDNA crach, we still have the TSoc
         list_volume_dst{end+1} = sprintf('rp_%s.txt',prefix);                  % motion paramters
         list_volume_dst = addprefixtofilenames(list_volume_dst,dir_func{subj}{run}); % path of the serie dir
         

--- a/SPM/preproc/job_realign.m
+++ b/SPM/preproc/job_realign.m
@@ -143,9 +143,10 @@ if obj && par.auto_add_obj
     serieArray      = [in_obj     .serie];
     serieArray_run1 = [in_obj(:,1).serie]; % the mean is only written in the run1
     tag             =  in_obj(1).tag;
+    ext             = '.*.nii$';
     
-    serieArray.     addVolume([ '^' par.prefix tag],[ par.prefix tag])
-    serieArray_run1.addVolume([ '^mean'        tag],[ 'mean'     tag])
+    serieArray.     addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
+    serieArray_run1.addVolume([ '^mean'        tag ext],[ 'mean'     tag])
     
 end
 

--- a/SPM/preproc/job_realign.m
+++ b/SPM/preproc/job_realign.m
@@ -18,6 +18,8 @@ obj = 0;
 if isa(in,'volume')
     obj = 1;
     in_obj  = in;
+    contains_gz = ~cellfun(@isempty,strfind(in_obj.getPath,'.nii.gz'));
+    assert( ~any(contains_gz(:)), 'Volumes must be unzip first. Use examArray.unzipVolume(par) or volumeArray.unzip(par).')
     in = in_obj.toJob(1);
 end
 
@@ -66,7 +68,7 @@ for subj = 1:nrSubject
     
     if obj
         if iscell(in{subj})
-            subjectRuns = unzip_volume(in{subj});
+            subjectRuns = in{subj};
         else
             subjectRuns = in;
         end

--- a/SPM/preproc/job_realign.m
+++ b/SPM/preproc/job_realign.m
@@ -23,9 +23,6 @@ obj = 0;
 if isa(in,'volume')
     obj = 1;
     in_obj  = in;
-    contains_gz = ~cellfun(@isempty,strfind(in_obj.getPath,'.nii.gz'));
-    assert( ~any(contains_gz(:)), 'Volumes must be unzip first. Use examArray.unzipVolume(par) or volumeArray.unzip(par).')
-    in = in_obj.toJob(1);
 end
 
 
@@ -48,6 +45,11 @@ defpar.redo    = 0;
 
 par = complet_struct(par,defpar);
 
+% Security
+if par.sge
+    par.auto_add_obj = 0;
+end
+
 
 %%  SPM:Spatial:Realign:Estimate & Reslice
 
@@ -58,6 +60,12 @@ switch par.type
         
     case 'estimate_and_reslice'
         par.which_write = [2 1];
+end
+
+% obj : unzip if necesary
+if obj
+    in_obj.unzip(par);
+    in = in_obj.toJob(1);
 end
 
 % nrSubject ?
@@ -80,7 +88,7 @@ for subj = 1:nrSubject
     else
         if iscell(in{1})
             subjectRuns = get_subdir_regex_files(in{subj},par.file_reg);
-            unzip_volume(subjectRuns);
+            unzip_volume(subjectRuns); % unzip if necesary
             subjectRuns = get_subdir_regex_files(in{subj},par.file_reg);
         else
             subjectRuns = in;

--- a/SPM/preproc/job_realign.m
+++ b/SPM/preproc/job_realign.m
@@ -1,17 +1,22 @@
 function jobs = job_realign(in,par)
 % JOB_REALIGN - SPM:Spatial:Realign:Estimate & Reslice
 %
-% in - can be multilevel-cell or @volume array
+% INPUT : fin can be 'char' of dir, multi-level 'cellstr' of dir, '@volume' array
 %
 % To build the image list easily, use get_subdir_regex & get_subdir_regex_files
 %
-% See also get_subdir_regex get_subdir_regex_files
+% See also get_subdir_regex get_subdir_regex_files exam exam.AddSerie exam.addVolume
 
 
 %% Check input arguments
 
 if ~exist('par','var')
     par = ''; % for defpar
+end
+
+if nargin < 1
+    help(mfilename)
+    error('[%s]: not enough input arguments - in is required',mfilename)
 end
 
 obj = 0;
@@ -145,8 +150,8 @@ if obj && par.auto_add_obj
     tag             =  in_obj(1).tag;
     ext             = '.*.nii$';
     
-    serieArray.     addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
-    serieArray_run1.addVolume([ '^mean'        tag ext],[ 'mean'     tag])
+    serieArray.     addVolume(['^' par.prefix tag ext],[par.prefix tag])
+    serieArray_run1.addVolume(['^mean'        tag ext],['mean'     tag])
     
 end
 

--- a/SPM/preproc/job_slice_timing.m
+++ b/SPM/preproc/job_slice_timing.m
@@ -176,8 +176,9 @@ if obj && par.auto_add_obj
     
     serieArray = [fin_obj.serie];
     tag        =  fin_obj(1).tag;
+    ext        = '.*.nii$';
     
-    serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
+    serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
     
 end
 

--- a/SPM/preproc/job_slice_timing.m
+++ b/SPM/preproc/job_slice_timing.m
@@ -1,13 +1,22 @@
 function jobs = job_slice_timing(fin,par)
 % JOB_SLICE_TIMING - SPM:Temporal:SliceTiming
 %
+% INPUT : fin can be 'char' of dir, multi-level 'cellstr' of dir, '@volume' array
+%
 % To build the image list easily, use get_subdir_regex & get_subdir_regex_files
 %
+% See also get_subdir_regex exam exam.AddSerie exam.addVolume
+
 
 %% Check input arguments
 
 if ~exist('par','var')
     par = ''; % for defpar
+end
+
+if nargin < 1
+    help(mfilename)
+    error('[%s]: not enough input arguments - fin is required',mfilename)
 end
 
 obj = 0;
@@ -178,7 +187,7 @@ if obj && par.auto_add_obj
     tag        =  fin_obj(1).tag;
     ext        = '.*.nii$';
     
-    serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
+    serieArray.addVolume(['^' par.prefix tag ext],[par.prefix tag])
     
 end
 

--- a/SPM/preproc/job_slice_timing.m
+++ b/SPM/preproc/job_slice_timing.m
@@ -23,8 +23,6 @@ obj = 0;
 if isa(fin,'volume')
     obj = 1;
     fin_obj  = fin;
-    contains_gz = ~cellfun(@isempty,strfind(fin_obj.getPath,'.nii.gz'));
-    assert( ~any(contains_gz(:)), 'Volumes must be unzip first. Use examArray.unzipVolume(par) or volumeArray.unzip(par).')
     fin = fin_obj.toJob(1);
 end
 
@@ -55,8 +53,19 @@ defpar.redo    = 0;
 
 par = complet_struct(par,defpar);
 
+% Security
+if par.sge
+    par.auto_add_obj = 0;
+end
+
 
 %% SPM:Temporal:SliceTiming
+
+% obj : unzip if necessary
+if obj
+    fin_obj.unzip(par);
+    fin = fin_obj.toJob(1);
+end
 
 if iscell( fin{1} )
     nSubj = length(fin);
@@ -77,7 +86,7 @@ for subj=1:nSubj
     else
         if iscell(fin{1})
             subjFiles = get_subdir_regex_files(fin{subj}, par.file_reg);
-            unzip_volume(subjFiles);
+            unzip_volume(subjFiles); % unzip if necessary
             subjFiles = get_subdir_regex_files(fin{subj}, par.file_reg);
         else
             subjFiles = fin;

--- a/SPM/preproc/job_slice_timing.m
+++ b/SPM/preproc/job_slice_timing.m
@@ -14,6 +14,8 @@ obj = 0;
 if isa(fin,'volume')
     obj = 1;
     fin_obj  = fin;
+    contains_gz = ~cellfun(@isempty,strfind(fin_obj.getPath,'.nii.gz'));
+    assert( ~any(contains_gz(:)), 'Volumes must be unzip first. Use examArray.unzipVolume(par) or volumeArray.unzip(par).')
     fin = fin_obj.toJob(1);
 end
 
@@ -59,7 +61,7 @@ for subj=1:nSubj
     
     if obj
         if iscell(fin{subj})
-            subjFiles = unzip_volume(fin{subj});
+            subjFiles = fin{subj};
         else
             subjFiles = fin;
         end

--- a/SPM/preproc/job_smooth.m
+++ b/SPM/preproc/job_smooth.m
@@ -13,6 +13,14 @@ if ~exist('par','var')
 end
 
 
+obj = 0;
+if isa(img,'volume')
+    obj = 1;
+    img_obj  = img;
+    img = img_obj.toJob(0);
+end
+
+
 %% defpar
 
 defpar.smooth   = [8 8 8];
@@ -21,6 +29,8 @@ defpar.prefix   = 's';
 defpar.sge      = 0;
 defpar.jobname  = 'spm_smooth';
 defpar.walltime = '00:30:00';
+
+defpar.auto_add_obj = 1;
 
 defpar.redo     = 0;
 defpar.run      = 0;
@@ -50,6 +60,18 @@ end
 %% Other routines
 
 [ jobs ] = job_ending_rountines( jobs, skip, par );
+
+
+%% Add outputs objects
+
+if obj && par.auto_add_obj
+    
+    serieArray = [img_obj.serie];
+    tag        =  img_obj(1).tag;
+    
+    serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
+    
+end
 
 
 end % function

--- a/SPM/preproc/job_smooth.m
+++ b/SPM/preproc/job_smooth.m
@@ -68,8 +68,9 @@ if obj && par.auto_add_obj
     
     serieArray = [img_obj.serie];
     tag        =  img_obj(1).tag;
+    ext        = '.*.nii$';
     
-    serieArray.addVolume([ '^' par.prefix tag],[ par.prefix tag])
+    serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
     
 end
 

--- a/SPM/preproc/job_smooth.m
+++ b/SPM/preproc/job_smooth.m
@@ -44,6 +44,11 @@ defpar.display  = 0;
 
 par = complet_struct(par,defpar);
 
+% Security
+if par.sge
+    par.auto_add_obj = 0;
+end
+
 
 %% SPM:Spatial:Smooth
 

--- a/SPM/preproc/job_smooth.m
+++ b/SPM/preproc/job_smooth.m
@@ -1,9 +1,11 @@
 function  jobs = job_smooth(img,par)
 % JOB_SMOOTH - SPM:Spatial:Smooth
 %
+% INPUT : img can be 'char' of volume(file), multi-level 'cellstr' of volume(file), '@volume' array
+%
 % To build the image list easily, use get_subdir_regex & get_subdir_regex_files
 %
-% See also get_subdir_regex get_subdir_regex_files
+% See also get_subdir_regex get_subdir_regex_files exam exam.AddSerie exam.addVolume
 
 
 %% Check input arguments
@@ -12,6 +14,10 @@ if ~exist('par','var')
     par = ''; % for defpar
 end
 
+if nargin < 1
+    help(mfilename)
+    error('[%s]: not enough input arguments - img is required',mfilename)
+end
 
 obj = 0;
 if isa(img,'volume')
@@ -70,7 +76,7 @@ if obj && par.auto_add_obj
     tag        =  img_obj(1).tag;
     ext        = '.*.nii$';
     
-    serieArray.addVolume([ '^' par.prefix tag ext],[ par.prefix tag])
+    serieArray.addVolume(['^' par.prefix tag ext],[par.prefix tag])
     
 end
 

--- a/Tools/nifti_hdr/unzip_volume.m
+++ b/Tools/nifti_hdr/unzip_volume.m
@@ -30,10 +30,10 @@ for i=1:length(in)
     
     if ~isempty(in{i}) && strcmp(in{i}(end-1:end),'gz')
         cmd{i} = sprintf('gunzip -f %s',in{i});
-        out{i} = in{i}(1:end-3); %#ok<*AGROW>
+        out{i,1} = in{i}(1:end-3); %#ok<*AGROW>
         
     else
-        out{i} = in{i};
+        out{i,1} = in{i};
         ind_to_remove(end+1)=i;
     end
     

--- a/Tools/utils/cellstr2regex.m
+++ b/Tools/utils/cellstr2regex.m
@@ -16,7 +16,12 @@ if nargin < 2
 end
 
 if numel(inputCELLSTR)==1 % str
-    regex = inputCELLSTR{1};
+    
+    if exactly
+        regex = ['^' inputCELLSTR{1} '$'];
+    else
+        regex = inputCELLSTR{1};
+    end
     
 elseif numel(inputCELLSTR)>1 % cellstr
     

--- a/Wrappers/do_fsl_add.m
+++ b/Wrappers/do_fsl_add.m
@@ -48,7 +48,7 @@ for ns=1:length(outnames)
     
     fo = cellstr(char(fos(ns)));
     outname = outnames{ns};
-    out{ns} = [outname ext]; %#ok<AGROW>
+    out{ns,1} = [outname ext]; %#ok<AGROW>
     
     % Skip outname already exists
     if ~par.redo   &&   exist(out{ns},'file')

--- a/Wrappers/do_fsl_mult.m
+++ b/Wrappers/do_fsl_mult.m
@@ -53,7 +53,7 @@ for ns=1:length(outname)
     
     %    fprintf('writing %s \n',outname)
     
-    out{ns} = [outname{ns} '.nii.gz']; %#ok<AGROW>
+    out{ns,1} = [outname{ns} '.nii.gz']; %#ok<AGROW>
     
     job(ns) = {cmd}; %#ok<AGROW>
     

--- a/objects/@exam/analyzeCountSeries.m
+++ b/objects/@exam/analyzeCountSeries.m
@@ -16,6 +16,8 @@ if ~exist('par','var')
 end
 
 defpar.serie_regex = '.*';
+defpar.N           = 1; % keep N best groups
+
 defpar.verbose     = 1;
 defpar.pct         = 0; % Parallel Computing Toolbox
 defpar.redo        = 0; % read again the json files & update @serie.sequence
@@ -33,107 +35,129 @@ par.redo = 0; % don't need anymore for he next json2table
 
 %% Pickup the best group
 
-% Hypothesis : the largest group in 'countSeries' is the "right" group, the one with the good number of sequences
+% OLD Hypothesis : the largest group in 'countSeries' is the "right" group, the one with the good number of sequences
+% New hypothesis : keep N best groups
 
-bestGroup = Group(end);
+nGroups = length(Group);
+N = min(nGroups,par.N);
 
-bestGroup_name_pattern = cellstr2regex(bestGroup.name,1);
-examArray_best = examArray.getExam(bestGroup_name_pattern);
+counter = 0;
 
-%TableParam_best = examArray_best.getSerie(par.serie_regex).json2table(par);
-TableSer_best   = examArray_best.countSeries(par.serie_regex);
-
-list_exam_best = {examArray_best.name}';
-summary_best = table2struct(TableSer_best(end,2:end));
-
-
-%% Best group info
-
-if par.verbose > 0
-    fprintf('\n')
-    cprintf('*comment','Largest group is N = %d/%d (%d %%)\n', bestGroup.N, length(examArray), round(100*bestGroup.N/length(examArray)))
-    disp(summary_best)
-    fprintf('\n')
-end
-
-if par.verbose > 1
-    cprintf('_comment','List for subjects\n')
-    cprintf('comment','%s\n',list_exam_best{:})
-    fprintf('\n')
-end
-
-list_sequence_best = fieldnames(summary_best);
-list_exam_name     = TableSer.Properties.RowNames;
-
-
-%% Exams with MORE than expected series (such as 2 T1w instead of 1)
-
-examArray_more = exam.empty;
-for seq = 1 : length(list_sequence_best)
-    index = TableSer.(list_sequence_best{seq}) > summary_best.(list_sequence_best{seq});
-    list_more = list_exam_name(index);
-    if par.verbose > 1
-        cprintf('key','Exam with '), cprintf('_key','more '), cprintf('*key','%s ',list_sequence_best{seq}), cprintf('key',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
-        if par.verbose > 1
-            fprintf('%s\n',list_more{:})
-        end
+for iGroup = nGroups : -1 : nGroups-N+1
+    
+    counter = counter + 1;
+    
+    bestGroup = Group(iGroup);
+    
+    bestGroup_name = [bestGroup.name];
+    examArray_best{counter} = examArray.getExam(bestGroup_name);
+    
+    %TableParam_best = examArray_best{counter}.getSerie(par.serie_regex).json2table(par);
+    TableSer_best   = examArray_best{counter}.countSeries(par.serie_regex);
+    
+    list_exam_best = {examArray_best{counter}.name}';
+    summary_best{counter} = table2struct(TableSer_best(end,2:end));
+    
+    
+    %% Best group info
+    
+    if par.verbose > 0
+        fprintf('\n')
+        cprintf('*comment','Largest group is N = %d/%d (%d %%)\n', bestGroup.N, length(examArray), round(100*bestGroup.N/length(examArray)))
+        disp(summary_best{counter})
         fprintf('\n')
     end
-    if ~isempty(list_more)
-        examArray_more = examArray_more.removeTag(cellstr2regex(list_more,1)) + examArray.getExam(cellstr2regex(list_more,1));
-    end
-end
-
-
-%% Exams with LESS than expected series (such as 0 T1w instead of 1)
-
-examArray_less = exam.empty;
-for seq = 1 : length(list_sequence_best)
-    index = TableSer.(list_sequence_best{seq}) < summary_best.(list_sequence_best{seq});
-    list_less = list_exam_name(index);
+    
     if par.verbose > 1
-        cprintf('err','Exam with '), cprintf('_err','less '), cprintf('*err','%s ',list_sequence_best{seq}), cprintf('err',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
-        if par.verbose > 1
-            fprintf('%s\n',list_less{:})
-        end
+        cprintf('_comment','List for subjects\n')
+        cprintf('comment','%s\n',list_exam_best{:})
         fprintf('\n')
     end
-    if ~isempty(list_less)
-        examArray_less = examArray_less.removeTag(cellstr2regex(list_less,1)) + examArray.getExam(cellstr2regex(list_less,1));
-    end
-end
-
-
-%% Exams with series that are NOT in the "best group" (where does this serie come from ?)
-
-list_sequence     = TableSer.Properties.VariableNames(2:end)';
-list_out_sequence = setxor(list_sequence_best,list_sequence);
-
-examArray_out = exam.empty;
-for seq = 1 : length(list_out_sequence)
-    index = TableSer.(list_out_sequence{seq}); index = logical(index);
-    list_out = list_exam_name(index);
-    if par.verbose > 1
-        cprintf('magenta','Exam with '), cprintf('*magenta','%s ',list_out_sequence{seq}), cprintf('magenta',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
+    
+    list_sequence_best = fieldnames(summary_best{counter});
+    list_exam_name     = TableSer.Properties.RowNames;
+    
+    
+    %% Exams with MORE than expected series (such as 2 T1w instead of 1)
+    
+    examArray_more{counter} = exam.empty;
+    for seq = 1 : length(list_sequence_best)
+        index = TableSer.(list_sequence_best{seq}) > summary_best{counter}.(list_sequence_best{seq});
+        list_more = list_exam_name(index);
         if par.verbose > 1
-            fprintf('%s\n',list_out{:})
+            cprintf('key','Exam with '), cprintf('_key','more '), cprintf('*key','%s ',list_sequence_best{seq}), cprintf('key',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
+            if par.verbose > 1
+                fprintf('%s\n',list_more{:})
+            end
+            fprintf('\n')
         end
-        fprintf('\n')
+        if ~isempty(list_more)
+            examArray_more{counter} = examArray_more{counter}.removeTag(cellstr2regex(list_more,1)) + examArray.getExam([list_more;{''}]);
+        end
     end
-    if ~isempty(list_out)
-        examArray_out = examArray_out.removeTag(cellstr2regex(list_out,1)) + examArray.getExam(cellstr2regex(list_out,1));
+    
+    
+    %% Exams with LESS than expected series (such as 0 T1w instead of 1)
+    
+    examArray_less{counter} = exam.empty;
+    for seq = 1 : length(list_sequence_best)
+        index = TableSer.(list_sequence_best{seq}) < summary_best{counter}.(list_sequence_best{seq});
+        list_less = list_exam_name(index);
+        if par.verbose > 1
+            cprintf('err','Exam with '), cprintf('_err','less '), cprintf('*err','%s ',list_sequence_best{seq}), cprintf('err',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
+            if par.verbose > 1
+                fprintf('%s\n',list_less{:})
+            end
+            fprintf('\n')
+        end
+        if ~isempty(list_less)
+            examArray_less{counter} = examArray_less{counter}.removeTag(cellstr2regex(list_less,1)) + examArray.getExam([list_less;{''}]);
+        end
     end
-end
+    
+    
+    %% Exams with series that are NOT in the "best group" (where does this serie come from ?)
+    
+    list_sequence     = TableSer.Properties.VariableNames(2:end)';
+    list_out_sequence = setxor(list_sequence_best,list_sequence);
+    
+    examArray_out{counter} = exam.empty;
+    for seq = 1 : length(list_out_sequence)
+        index = TableSer.(list_out_sequence{seq}); index = logical(index);
+        list_out = list_exam_name(index);
+        if par.verbose > 1
+            cprintf('magenta','Exam with '), cprintf('*magenta','%s ',list_out_sequence{seq}), cprintf('magenta',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
+            if par.verbose > 1
+                fprintf('%s\n',list_out{:})
+            end
+            fprintf('\n')
+        end
+        if ~isempty(list_out)
+            examArray_out{counter} = examArray_out{counter}.removeTag(cellstr2regex(list_out,1)) + examArray.getExam([list_out;{''}]);
+        end
+    end
+    
+    
+end % iGroup
 
 
 %% Output
 
 if nargout > 0
     varargout = {};
-    varargout{end+1} = examArray_best; % best group
-    varargout{end+1} = examArray_more; % MORE than expected
-    varargout{end+1} = examArray_less; % LESS than expected
-    varargout{end+1} = examArray_out ; % ?
+    if par.N == 1
+        varargout{end+1} = examArray_best{1}; % best group
+        varargout{end+1} = examArray_more{1}; % MORE than expected
+        varargout{end+1} = examArray_less{1}; % LESS than expected
+        varargout{end+1} = examArray_out {1}; % ?
+        varargout{end+1} = summary_best  {1}; % info
+    else
+        varargout{end+1} = examArray_best; % best group
+        varargout{end+1} = examArray_more; % MORE than expected
+        varargout{end+1} = examArray_less; % LESS than expected
+        varargout{end+1} = examArray_out ; % ?
+        varargout{end+1} = summary_best  ; % info
+    end
 end
 
 

--- a/objects/@exam/analyzeCountSeries.m
+++ b/objects/@exam/analyzeCountSeries.m
@@ -50,16 +50,16 @@ summary_best = table2struct(TableSer_best(end,2:end));
 %% Best group info
 
 if par.verbose > 0
-    
     fprintf('\n')
     cprintf('*comment','Largest group is N = %d/%d (%d %%)\n', bestGroup.N, length(examArray), round(100*bestGroup.N/length(examArray)))
     disp(summary_best)
     fprintf('\n')
-    
+end
+
+if par.verbose > 1
     cprintf('_comment','List for subjects\n')
     cprintf('comment','%s\n',list_exam_best{:})
     fprintf('\n')
-    
 end
 
 list_sequence_best = fieldnames(summary_best);
@@ -72,9 +72,11 @@ examArray_more = exam.empty;
 for seq = 1 : length(list_sequence_best)
     index = TableSer.(list_sequence_best{seq}) > summary_best.(list_sequence_best{seq});
     list_more = list_exam_name(index);
-    if par.verbose > 0
+    if par.verbose > 1
         cprintf('key','Exam with '), cprintf('_key','more '), cprintf('*key','%s ',list_sequence_best{seq}), cprintf('key',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
-        fprintf('%s\n',list_more{:})
+        if par.verbose > 1
+            fprintf('%s\n',list_more{:})
+        end
         fprintf('\n')
     end
     if ~isempty(list_more)
@@ -89,9 +91,11 @@ examArray_less = exam.empty;
 for seq = 1 : length(list_sequence_best)
     index = TableSer.(list_sequence_best{seq}) < summary_best.(list_sequence_best{seq});
     list_less = list_exam_name(index);
-    if par.verbose > 0
+    if par.verbose > 1
         cprintf('err','Exam with '), cprintf('_err','less '), cprintf('*err','%s ',list_sequence_best{seq}), cprintf('err',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
-        fprintf('%s\n',list_less{:})
+        if par.verbose > 1
+            fprintf('%s\n',list_less{:})
+        end
         fprintf('\n')
     end
     if ~isempty(list_less)
@@ -109,9 +113,11 @@ examArray_out = exam.empty;
 for seq = 1 : length(list_out_sequence)
     index = TableSer.(list_out_sequence{seq}); index = logical(index);
     list_out = list_exam_name(index);
-    if par.verbose > 0
+    if par.verbose > 1
         cprintf('magenta','Exam with '), cprintf('*magenta','%s ',list_out_sequence{seq}), cprintf('magenta',', N = %d (%d %%)\n',sum(index), round(100*sum(index)/length(examArray)))
-        fprintf('%s\n',list_out{:})
+        if par.verbose > 1
+            fprintf('%s\n',list_out{:})
+        end
         fprintf('\n')
     end
     if ~isempty(list_out)

--- a/objects/@exam/compareOrientation.m
+++ b/objects/@exam/compareOrientation.m
@@ -86,6 +86,7 @@ if par.verbose > 0
     fprintf('good       N = %d/%d (%d%%)\n', N_good      , N, round(100*N_good      /N))
     fprintf('bad_orient N = %d/%d (%d%%)\n', N_bad_orient, N, round(100*N_bad_orient/N))
     fprintf('bad_dim    N = %d/%d (%d%%)\n', N_bad_dim   , N, round(100*N_bad_dim   /N))
+    fprintf('\n')
 end
 
 

--- a/objects/@exam/compareOrientation.m
+++ b/objects/@exam/compareOrientation.m
@@ -32,61 +32,65 @@ good       = exam.empty;
 bad_orient = exam.empty;
 bad_dim    = exam.empty;
 
-for ex = 1 : size(serieArray,1)
+if numel(serieArray) ~= 0
     
-    orientation = zeros(6+3,size(serieArray,2));
-    dim         = zeros(3,size(serieArray,2));
-    
-    for ser = 1 : size(serieArray,2)
+    for ex = 1 : size(serieArray,1)
         
-        orientation(1:6,ser) = serieArray(ex,ser).sequence.ImageOrientationPatient; % 6 x 1
-        orientation(  7,ser) = serieArray(ex,ser).sequence.sPositiondCor;
-        orientation(  8,ser) = serieArray(ex,ser).sequence.sPositiondTra;
-        orientation(  9,ser) = serieArray(ex,ser).sequence.sNormaldTra;
-        dim(1,ser)           = serieArray(ex,ser).sequence.Rows;
-        dim(2,ser)           = serieArray(ex,ser).sequence.Columns;
-        dim(3,ser)           = serieArray(ex,ser).sequence.Slices;
+        orientation = zeros(6+3,size(serieArray,2));
+        dim         = zeros(3,size(serieArray,2));
+        
+        for ser = 1 : size(serieArray,2)
+            
+            orientation(1:6,ser) = serieArray(ex,ser).sequence.ImageOrientationPatient; % 6 x 1
+            orientation(  7,ser) = serieArray(ex,ser).sequence.sPositiondCor;
+            orientation(  8,ser) = serieArray(ex,ser).sequence.sPositiondTra;
+            orientation(  9,ser) = serieArray(ex,ser).sequence.sNormaldTra;
+            dim(1,ser)           = serieArray(ex,ser).sequence.Rows;
+            dim(2,ser)           = serieArray(ex,ser).sequence.Columns;
+            dim(3,ser)           = serieArray(ex,ser).sequence.Slices;
+            
+        end
+        
+        orient_differs = any( any( abs( orientation - orientation(:,1) ) > 1e-6 ) );
+        if orient_differs
+            if par.verbose > 1
+                fprintf('Orientation differs in \n%s\n', serieArray(ex,ser).exam.path)
+                disp(orientation)
+            end
+            bad_orient(end+1) = examArray(ex); %#ok<AGROW>
+        end
+        
+        dim_differs = any( any( abs( dim - dim(:,1) ) > 1e-3 ) );
+        if dim_differs
+            if par.verbose > 1
+                fprintf('Dimension differs in \n%s\n', serieArray(ex,ser).exam.path)
+                disp(dim)
+            end
+            bad_dim(end+1) = examArray(ex); %#ok<AGROW>
+        end
+        
+        if orient_differs || dim_differs
+            if par.verbose > 1
+                fprintf('\n')
+            end
+        else
+            good(end+1) = examArray(ex); %#ok<AGROW>
+        end
         
     end
     
-    orient_differs = any( any( abs( orientation - orientation(:,1) ) > 1e-6 ) );
-    if orient_differs
-        if par.verbose > 1
-            fprintf('Orientation differs in \n%s\n', serieArray(ex,ser).exam.path)
-            disp(orientation)
-        end
-        bad_orient(end+1) = examArray(ex); %#ok<AGROW>
+    % Sumup
+    N            = numel(examArray);
+    N_good       = numel(good);
+    N_bad_orient = numel(bad_orient);
+    N_bad_dim    = numel(bad_dim);
+    if par.verbose > 0
+        fprintf('good       N = %d/%d (%d%%)\n', N_good      , N, round(100*N_good      /N))
+        fprintf('bad_orient N = %d/%d (%d%%)\n', N_bad_orient, N, round(100*N_bad_orient/N))
+        fprintf('bad_dim    N = %d/%d (%d%%)\n', N_bad_dim   , N, round(100*N_bad_dim   /N))
+        fprintf('\n')
     end
     
-    dim_differs = any( any( abs( dim - dim(:,1) ) > 1e-3 ) );
-    if dim_differs
-        if par.verbose > 1
-            fprintf('Dimension differs in \n%s\n', serieArray(ex,ser).exam.path)
-            disp(dim)
-        end
-        bad_dim(end+1) = examArray(ex); %#ok<AGROW>
-    end
-    
-    if orient_differs || dim_differs
-        if par.verbose > 1
-            fprintf('\n')
-        end
-    else
-        good(end+1) = examArray(ex); %#ok<AGROW>
-    end
-    
-end
-
-% Sumup
-N            = numel(examArray);
-N_good       = numel(good);
-N_bad_orient = numel(bad_orient);
-N_bad_dim    = numel(bad_dim);
-if par.verbose > 0
-    fprintf('good       N = %d/%d (%d%%)\n', N_good      , N, round(100*N_good      /N))
-    fprintf('bad_orient N = %d/%d (%d%%)\n', N_bad_orient, N, round(100*N_bad_orient/N))
-    fprintf('bad_dim    N = %d/%d (%d%%)\n', N_bad_dim   , N, round(100*N_bad_dim   /N))
-    fprintf('\n')
 end
 
 

--- a/objects/@exam/compareOrientation.m
+++ b/objects/@exam/compareOrientation.m
@@ -51,7 +51,7 @@ for ex = 1 : size(serieArray,1)
     
     orient_differs = any( any( abs( orientation - orientation(:,1) ) > 1e-6 ) );
     if orient_differs
-        if par.verbose
+        if par.verbose > 1
             fprintf('Orientation differs in \n%s\n', serieArray(ex,ser).exam.path)
             disp(orientation)
         end
@@ -60,7 +60,7 @@ for ex = 1 : size(serieArray,1)
     
     dim_differs = any( any( abs( dim - dim(:,1) ) > 1e-3 ) );
     if dim_differs
-        if par.verbose
+        if par.verbose > 1
             fprintf('Dimension differs in \n%s\n', serieArray(ex,ser).exam.path)
             disp(dim)
         end
@@ -68,7 +68,7 @@ for ex = 1 : size(serieArray,1)
     end
     
     if orient_differs || dim_differs
-        if par.verbose
+        if par.verbose > 1
             fprintf('\n')
         end
     else
@@ -82,7 +82,7 @@ N            = numel(examArray);
 N_good       = numel(good);
 N_bad_orient = numel(bad_orient);
 N_bad_dim    = numel(bad_dim);
-if par.verbose
+if par.verbose > 0
     fprintf('good       N = %d/%d (%d%%)\n', N_good      , N, round(100*N_good      /N))
     fprintf('bad_orient N = %d/%d (%d%%)\n', N_bad_orient, N, round(100*N_bad_orient/N))
     fprintf('bad_dim    N = %d/%d (%d%%)\n', N_bad_dim   , N, round(100*N_bad_dim   /N))

--- a/objects/@exam/countSeries.m
+++ b/objects/@exam/countSeries.m
@@ -26,24 +26,24 @@ for ex = 1 : numel(examArray)
     
     serieArray = examArray(ex).getSerie(serie_regex,'tag',0);
     
-    exam_tags  = {serieArray.tag};
-    exam_nicks = unique({serieArray.nick});
-    exam_path  = {serieArray.path};
-    valid_path = ~cellfun( @isempty, exam_path );
+    serie_tags  = {serieArray.tag};
+    serie_nicks = unique({serieArray.nick});
+    serie_path  = {serieArray.path};
+    valid_path  = ~cellfun( @isempty, serie_path );
     
     % addSerie, when tags are not found, adds an empty serie (for diagnostic purpose)
     % empty serie means serie WITH tag, and WITHOUT nick
     % but in this partical countSeries function, we count the tags
     % so here we need an exeption to discard the exams with only empty series
-    if isempty(char(exam_nicks))
+    if isempty(char(serie_nicks))
         continue
     end
     
-    nick = unique([nick(:)' exam_nicks],'stable'); % concatenate previous nicks and new nicks, and keep only unique ones in the same order
+    nick = unique([nick(:)' serie_nicks],'stable'); % concatenate previous nicks and new nicks, and keep only unique ones in the same order
     nick(cellfun(@isempty,nick)) = [];             % remove empty tags
     
     for n = 1 : length(nick)
-        found_tags_idx = ~cellfun( @isempty, regexp(exam_tags,nick{n}) );
+        found_tags_idx = ~cellfun( @isempty, regexp(serie_tags,nick{n}) );
         N = sum ( found_tags_idx & valid_path );
         NrSerie(ex,n) = N;
     end

--- a/objects/@exam/countSeries.m
+++ b/objects/@exam/countSeries.m
@@ -60,6 +60,17 @@ NrSerie = NrSerie(:,nick_order);
 %% Sort NrSerie matrix
 
 ExamName = {examArray.name}';
+idxkeep = non_unique( ExamName ); % non unique ? then add random chars in the end
+while sum(idxkeep) > 0
+    random_chars      = regexprep(cellstr(num2str(randi(9,[sum(idxkeep) 8]))),' ',''); % generate random numbers, and convert them into char
+    ExamName(idxkeep) = strcat(ExamName(idxkeep),'_',random_chars);                    % concat name with random chars
+    idxkeep           = non_unique( ExamName );                                        % update the measure of non-unique
+end
+for ex = 1 : numel(examArray)
+    examArray(ex).name = ExamName{ex};
+end
+ExamName = {examArray.name}'; % now we have unique names
+
 [~,IA,IC] = unique(NrSerie,'rows');
 
 Group = struct;
@@ -96,3 +107,11 @@ end
 
 
 end % end
+
+function idxkeep = non_unique( in )
+
+[~,idxu,idxc] = unique(in);
+[count, ~, idxcount] = histcounts(idxc,numel(idxu));
+idxkeep = count(idxcount)>1;
+
+end

--- a/objects/@exam/countSeries.m
+++ b/objects/@exam/countSeries.m
@@ -59,17 +59,7 @@ NrSerie = NrSerie(:,nick_order);
 
 %% Sort NrSerie matrix
 
-ExamName = {examArray.name}';
-idxkeep = non_unique( ExamName ); % non unique ? then add random chars in the end
-while sum(idxkeep) > 0
-    random_chars      = regexprep(cellstr(num2str(randi(9,[sum(idxkeep) 8]))),' ',''); % generate random numbers, and convert them into char
-    ExamName(idxkeep) = strcat(ExamName(idxkeep),'_',random_chars);                    % concat name with random chars
-    idxkeep           = non_unique( ExamName );                                        % update the measure of non-unique
-end
-for ex = 1 : numel(examArray)
-    examArray(ex).name = ExamName{ex};
-end
-ExamName = {examArray.name}'; % now we have unique names
+ExamName = matlab.lang.makeUniqueStrings({examArray.name}');
 
 [~,IA,IC] = unique(NrSerie,'rows');
 
@@ -107,11 +97,3 @@ end
 
 
 end % end
-
-function idxkeep = non_unique( in )
-
-[~,idxu,idxc] = unique(in);
-[count, ~, idxcount] = histcounts(idxc,numel(idxu));
-idxkeep = count(idxcount)>1;
-
-end

--- a/objects/@exam/getExam.m
+++ b/objects/@exam/getExam.m
@@ -4,6 +4,8 @@ function [ exams ] = getExam( examArray, regex, verbose )
 %           ex = examArray.getExam('Subject02');
 %           ex = examArray.getExam('Subject');
 %           ex = examArray.getExam('V2');
+%
+% If the regex is a cellstr, the reserach will be performed on each element, with an exact comparasion, not a regexp
 
 
 %% Check inputs
@@ -18,6 +20,12 @@ end
 
 AssertIsCharOrCellstr(regex)
 
+exact_tag = 0;
+if iscellstr(regex)
+    n_regex = length(regex);
+    exact_tag = 1;
+end
+
 
 %% getExam from @exam
 
@@ -26,18 +34,34 @@ exams = exam.empty;
 
 counter = 0;
 
-for ex = 1 : numel(examArray)
+if exact_tag
     
-    if ...
-            ~isempty(examArray(ex).tag) && ...                 % name is present in the @exam ?
-            ~isempty(regexp(examArray(ex).tag, regex, 'once')) % found a corresponding exma.name to the regex ?
-        
-        counter = counter + 1;
-        exams(counter,1) = examArray(ex);
-        
+    Tags = {examArray.tag}';
+    for r = 1 : n_regex
+        res = strcmp(Tags,regex{r});
+        if sum(res)>0
+            exams = exams + examArray(res);
+        end
     end
     
-end % exam
+else
+    
+    for ex = 1 : numel(examArray)
+        
+        if ...
+                ~isempty(examArray(ex).tag) && ...                 % name is present in the @exam ?
+                ~isempty(regexp(examArray(ex).tag, regex, 'once')) % found a corresponding exma.name to the regex ?
+            
+            counter = counter + 1;
+            exams(counter,1) = examArray(ex);
+            
+        end
+        
+        
+        
+    end % exam
+    
+end
 
 
 %% Error if nothing found

--- a/objects/@exam/regroupSeries.m
+++ b/objects/@exam/regroupSeries.m
@@ -90,7 +90,9 @@ for i = 1 : length(IA)
     Group(i).param_str = param_str(logical(Group(i).array(1,:)))';
     
     idx_array = find(Group(i).array(1,:));
-    if ~isempty(idx_array)
+    if isempty(idx_array)
+        Group(i).table = table; % empty table
+    else
         clear tmp_struct
         found_nick = cell(size(idx_array));
         for seq_idx = 1 : length(idx_array)

--- a/objects/@exam/regroupSeries.m
+++ b/objects/@exam/regroupSeries.m
@@ -1,0 +1,146 @@
+function varargout = regroupSeries( examArray, par )
+% REGROUPSERIES similar from countSeries, but using sequence paramters instead of the serie.tag
+%
+% Syntax : [Table, Group] = examArray.regroupSeries(par)
+%          [Table, Group] = examArray.regroupSeries
+%                           examArray.regroupSeries(par)
+%                           examArray.regroupSeries
+%
+% Notes : accepted list of parameters comes from serie.seq2str method
+%
+
+
+%% Check input arguments
+
+if ~exist('par','var')
+    par = ''; % for defpar
+end
+
+defpar.serie_regex = '.*';
+defpar.param_list  = '';   % use default list from seq2str
+
+par = complet_struct(par,defpar);
+
+
+%% Count the series
+
+% Fetch sequence parameters
+serieArray                                          = examArray.getSerie(par.serie_regex,'tag',0);
+[seq_param_str, seq_param_struct, requested_param ] = serieArray.seq2str(par.param_list); %#ok<ASGLU>
+nick                                                = reshape({serieArray.nick},size(serieArray));
+
+% Concat : id = seqeunce.nick + seq_param_str
+id = strcat(nick,':',seq_param_str);
+id(~cellfun(@isempty,regexp(id,'^\s?:\s?$'))) = {''};
+
+% Initialize, with the firt exam
+param_str = id(1,:);
+param_str = unique(param_str);
+param_str(cellfun(@isempty,param_str)) = []; % remove empty tags
+NrSerie   = zeros( numel(examArray), numel(param_str));
+
+% Count the series, using the 'nick' (initial tag, no increment)
+for ex = 1 : numel(examArray)
+    
+    serie_param        = id(ex,:);
+    serie_unique_param = unique(serie_param);
+    
+    % addSerie, when tags are not found, adds an empty serie (for diagnostic purpose)
+    % empty serie means serie WITH tag, and WITHOUT nick
+    % but in this partical regroupSeries function, we count the tags
+    % so here we need an exeption to discard the exams with only empty series
+    if isempty(char(serie_param))
+        continue
+    end
+    
+    param_str = unique([param_str(:)' serie_unique_param],'stable'); % concatenate previous nicks and new nicks, and keep only unique ones in the same order
+    
+    param_str(cellfun(@isempty,param_str)) = [];             % remove empty tags
+    
+    for n = 1 : length(param_str)
+        found_tags_idx = ~cellfun( @isempty, regexp(serie_param,param_str{n}) );
+        N = sum( found_tags_idx );
+        NrSerie(ex,n) = N;
+    end
+    
+end
+
+
+%% Reorder : alphabetical
+
+[param_str,nick_order] = sort(param_str);
+NrSerie = NrSerie(:,nick_order);
+
+
+%% Make groups according to NrSeries
+
+ExamName = matlab.lang.makeUniqueStrings({examArray.name}');
+
+[~,IA,IC] = unique(NrSerie,'rows');
+
+Group = struct;
+
+for i = 1 : length(IA)
+    Group(i).idx   = i==IC;
+    Group(i).array = NrSerie(Group(i).idx,:);
+    Group(i).name  = ExamName(Group(i).idx);
+    Group(i).N     = size(Group(i).array,1);
+    Group(i).Nrep  = repmat(Group(i).N,[Group(i).N,1]);
+    
+    Group(i).param_str = param_str(logical(Group(i).array(1,:)))';
+    
+    idx_array = find(Group(i).array(1,:));
+    if ~isempty(idx_array)
+        clear tmp_struct
+        found_nick = cell(size(idx_array));
+        for seq_idx = 1 : length(idx_array)
+            found_idx = strcmp(Group(i).param_str{seq_idx}, id);
+            found_idx = find(found_idx);
+            found_idx = found_idx(1);
+            tmp_struct(seq_idx) = complet_struct( struct('N',Group(i).array(1,idx_array(seq_idx))), seq_param_struct{found_idx}); %#ok<AGROW>
+            found_nick{seq_idx} = nick{found_idx};
+        end
+        Group(i).table = struct2table(tmp_struct,'AsArray',1,'RowNames',matlab.lang.makeUniqueStrings(found_nick));
+    end
+    
+end
+
+% Finaly
+[ ~ , order ]   = sort( [Group.N] );
+Group           = Group(order);
+OrderedNrSerie  = [cat(1,Group.Nrep) cat(1,Group.array)];
+OrederdExamName = cat(1,Group.name);
+
+
+%% Fetch serie nick, to use it as row name
+
+nick = nick(:);
+id   = id(:); % same dimension
+
+final_nick = cell(size(param_str));
+for p = 1 : length(param_str)
+    res = strcmp(param_str{p},id);
+    assert(~isempty(res))
+    final_nick{p} = nick{find(res,1)};
+end
+final_nick = matlab.lang.makeUniqueStrings(final_nick);
+
+
+%% Convert the num array to a table
+
+Table                          = array2table(OrderedNrSerie);
+Table.Properties.RowNames      = OrederdExamName;
+Table.Properties.VariableNames = [ {'NrExam'} final_nick ];
+
+
+%% Output
+
+if nargout > 0
+    varargout{1} = Table;
+    varargout{2} = Group;
+else
+    disp(Table)
+end
+
+
+end % end

--- a/objects/@mvObject/sumup.m
+++ b/objects/@mvObject/sumup.m
@@ -21,8 +21,7 @@ if remove_obj
 end
 
 % Convert to table
-Table = struct2table(s);
-% Table.Properties.RowNames
+Table = struct2table(s,'AsArray',1);
 
 % Output
 if nargout

--- a/objects/@mvObject/sumup.m
+++ b/objects/@mvObject/sumup.m
@@ -1,0 +1,34 @@
+function varargout = sumup( mvArray, remove_obj )
+%SUMUP converts the mvArray into a table, and print it
+
+if nargin < 2
+    remove_obj = 1;
+end
+
+% To structure, because it's easer to convert into table
+s = mvArray.toStruct;
+
+if remove_obj
+    
+    % Remove the non builtin datatypes
+    fields = fieldnames(s);
+    for f = 1 : length(fields)
+        if ~exist(class(mvArray(1).(fields{f})),'builtin')
+            s = rmfield(s,fields{f});
+        end
+    end
+    
+end
+
+% Convert to table
+Table = struct2table(s);
+% Table.Properties.RowNames
+
+% Output
+if nargout
+    varargout{1} = Table;
+else
+    disp(Table)
+end
+
+end % function

--- a/objects/@mvObject/toJob.m
+++ b/objects/@mvObject/toJob.m
@@ -35,7 +35,7 @@ for idx = 1:size(mvArray,1)
     
     if flag
         
-        pathArray{idx} = {mvArray(idx,:).path};
+        pathArray{idx} = {mvArray(idx,:).path}';
         
         % to simulate the output of get_subdir_regex_multi
         if isempty(char(mvArray(idx,:).path))

--- a/objects/@mvObject/toStruct.m
+++ b/objects/@mvObject/toStruct.m
@@ -1,0 +1,14 @@
+function structure = toStruct( mvArray )
+% TOSTRUCT Export all proporties of the object into a structure, so it can be saved.
+
+ListProperties = properties(mvArray);
+
+structure = struct;
+
+for mv = 1 : numel(mvArray)
+    for prop_number = 1:length(ListProperties)
+        structure(mv,1).(ListProperties{prop_number}) = mvArray(mv).(ListProperties{prop_number});
+    end
+end
+
+end % function

--- a/objects/@mvObject/unique.m
+++ b/objects/@mvObject/unique.m
@@ -1,0 +1,9 @@
+function [C,IA,IC] = unique( in_mvArray )
+
+in_path = in_mvArray.getPath;
+
+[~,IA,IC] = unique(in_path,'stable');
+
+C = in_mvArray(IA);
+
+end % function

--- a/objects/@serie/seq2str.m
+++ b/objects/@serie/seq2str.m
@@ -1,0 +1,88 @@
+function varargout = seq2str( serieArray, param_list )
+%SEQ2STR fetch the parameters in serieArray.sequence, according to the paramList.
+% Then, converte them to a cellstr(dimension of serieArray)
+
+
+%% Check input arguments
+
+if nargin < 2 || isempty(param_list)
+    param_list = {'TR', 'TE', 'seqname', 'pxdim', 'mxdim'};
+end
+
+nParam = length(param_list);
+
+
+%% Prepare structure
+
+cellstruct = cell(size(serieArray)); % pre-allocation
+out        = cell(size(serieArray));
+
+if numel(serieArray) > 0
+    
+    
+    for idx = 1 : numel(serieArray)
+        
+        seq = serieArray(idx).sequence(1); % only keep first echo
+        if isempty(fieldnames(seq))
+            continue
+        end
+        
+        param = struct;
+        for p = 1 : nParam
+            switch param_list{p}
+                
+                % Deflaut parameters, all sequences
+                case 'TR'
+                    param.TR = seq.RepetitionTime*1000;
+                case 'TE'
+                    param.TE = seq.EchoTime*1000;
+                case 'seqname'
+                    param.seqname = seq.SequenceFileName;
+                case 'pxdim'
+                    param.pxdim = [seq.PixelSpacing' seq.SliceThickness];
+                case 'mxdim'
+                    param.mxdim = [seq.Rows seq.Columns seq.Slices];
+                    
+                    % Other parameters
+                case 'TI'
+                    param.TI = seq.InversionTime*1000;
+                    
+                    % unknown parameter ?
+                otherwise
+                    error('[%s]: "%s" not coded yet', mfilename, param_list{p} )
+            end
+        end
+        
+        cellstruct{idx} = param;
+        
+    end
+    
+    % Create an "empty" param structure, to fill the voids
+    fields = fieldnames(param);
+    empty_param = param;
+    for f = 1 : length(fields)
+        empty_param.(fields{f}) = '';
+    end
+    cellstruct(cellfun(@isempty,cellstruct)) = {empty_param}; % fill the voids
+    
+    
+    %% Convert structure into char
+    
+    for idx = 1 : numel(serieArray)
+        out{idx} = str2char(cellstruct{idx});
+    end
+    
+    
+end
+
+
+%% Output
+
+if nargout
+    varargout{1} = out;
+else
+    disp(char(out(:)'))
+end
+
+
+end % function

--- a/objects/@serie/seq2str.m
+++ b/objects/@serie/seq2str.m
@@ -1,9 +1,13 @@
-function varargout = seq2str( serieArray, param_list )
+function varargout = seq2str( serieArray, param_list, identifier )
 %SEQ2STR fetch the parameters in serieArray.sequence, according to the paramList.
 % Then, converte them to a cellstr(dimension of serieArray)
 
 
 %% Check input arguments
+
+if nargin < 3
+    identifier = '';
+end
 
 if nargin < 2 || isempty(param_list)
     param_list = {'TR', 'TE', 'seqname', 'pxdim', 'mxdim'};
@@ -22,9 +26,16 @@ if numel(serieArray) > 0
     
     for idx = 1 : numel(serieArray)
         
-        seq = serieArray(idx).sequence(1); % only keep first echo
+        seq = serieArray(idx).sequence;
         if isempty(fieldnames(seq))
             continue
+        end
+        
+        % only keep first echo
+        if length(seq)>1
+            allTE = [seq.EchoTime];
+            [sortedTE,orderTE] = sort(allTE); %#ok<ASGLU>
+            seq = seq(orderTE(1));
         end
         
         param = struct;
@@ -69,7 +80,7 @@ if numel(serieArray) > 0
     %% Convert structure into char
     
     for idx = 1 : numel(serieArray)
-        out{idx} = str2char(cellstruct{idx});
+        out{idx} = str2char(cellstruct{idx},identifier);
     end
     
     
@@ -80,6 +91,8 @@ end
 
 if nargout
     varargout{1} = out;
+    varargout{2} = cellstruct;
+    varargout{3} = param_list; % in case of using default param_list
 else
     disp(char(out(:)'))
 end

--- a/objects/@serie/seq2str.m
+++ b/objects/@serie/seq2str.m
@@ -60,7 +60,12 @@ if numel(serieArray) > 0
                     
                     % unknown parameter ?
                 otherwise
-                    error('[%s]: "%s" not coded yet', mfilename, param_list{p} )
+                    
+                    if isfield(seq,param_list{p})
+                        param.(param_list{p}) = seq.(param_list{p});
+                    else
+                        error('[%s]: "%s" not coded yet', mfilename, param_list{p} )
+                    end
             end
         end
         

--- a/objects/auto_import_obj.m
+++ b/objects/auto_import_obj.m
@@ -95,19 +95,20 @@ par = complet_struct(par,defpar);
 % 4 : volume tag
 % 5 : json   tag
 SequenceCategory = {
-    'tfl'                'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % 3DT1 mprage & mp2rage
-    'mp2rage'            'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % some mp2rage WIP
-    'tse_vfl'            'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % 3DT2 space & 3DFLAIR space_ir
-    'diff'               'dwi'   par.  dwi_regex_volume  par.  dwi_tag_volume  par.  dwi_tag_json % diffusion
-    '(bold)|(pace)'      'func'  par. func_regex_volume  par. func_tag_volume  par. func_tag_json % bold fmri
-    'gre_field_mapping'  'fmap'  par. fmap_regex_volume  par. fmap_tag_volume  par. fmap_tag_json % gre_field_mapping
-    '^gre$'              'swi'   par.  swi_regex_volume  par.  swi_tag_volume  par.  swi_tag_json % gre SWI
-    '^gre$'              'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % gre FLASH
-    '^tse$'              'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % tse, usually AX_2DT1 or AX_2DT2
-    'ep2d_se'            'anat'  par. func_regex_volume  par. anat_tag_volume  par. anat_tag_json % SpinEcho EPI
-    'pcasl'              'asl'   par.  asl_regex_volume  par.  asl_tag_volume  par.  asl_tag_json % pCASL
-    'pasl'               'asl'   par.  asl_regex_volume  par.  asl_tag_volume  par.  asl_tag_json % 3DASL
-    'medic'              'medic' par.medic_regex_volume  par.medic_tag_volume  par.medic_tag_json % medic
+    'tfl'                          'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % 3DT1 mprage & mp2rage
+    'mp2rage'                      'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % some mp2rage WIP
+    'tse_vfl'                      'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % 3DT2 space & 3DFLAIR space_ir
+    'diff'                         'dwi'   par.  dwi_regex_volume  par.  dwi_tag_volume  par.  dwi_tag_json % diffusion
+    'PtkSmsVB13ADwDualSpinEchoEpi' 'dwi'   par.  dwi_regex_volume  par.  dwi_tag_volume  par.  dwi_tag_json % diffusion from Trio 
+    '(bold)|(pace)'                'func'  par. func_regex_volume  par. func_tag_volume  par. func_tag_json % bold fmri
+    'gre_field_mapping'            'fmap'  par. fmap_regex_volume  par. fmap_tag_volume  par. fmap_tag_json % gre_field_mapping
+    '^gre$'                        'swi'   par.  swi_regex_volume  par.  swi_tag_volume  par.  swi_tag_json % gre SWI
+    '^gre$'                        'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % gre FLASH
+    '^tse$'                        'anat'  par. anat_regex_volume  par. anat_tag_volume  par. anat_tag_json % tse, usually AX_2DT1 or AX_2DT2
+    'ep2d_se'                      'anat'  par. func_regex_volume  par. anat_tag_volume  par. anat_tag_json % SpinEcho EPI
+    'pcasl'                        'asl'   par.  asl_regex_volume  par.  asl_tag_volume  par.  asl_tag_json % pCASL
+    'pasl'                         'asl'   par.  asl_regex_volume  par.  asl_tag_volume  par.  asl_tag_json % 3DASL
+    'medic'                        'medic' par.medic_regex_volume  par.medic_tag_volume  par.medic_tag_json % medic
     };
 
 

--- a/objects/get_sequence_param_from_json.m
+++ b/objects/get_sequence_param_from_json.m
@@ -120,12 +120,17 @@ for j = 1 : size(json_filename,1)
         data_file.SliceTiming = SliceTiming;
         
         % bvals & bvecs
-        B_value                  =             get_field_mul     (content, 'CsaImage.B_value', 0); B_value = str2double(B_value)';
+        B_value                  =             get_field_mul     (content, 'CsaImage.B_value', 0);
+        B_value                  = str2double(B_value)';
         data_file.B_value        = B_value;
         B_vect                   =             get_field_mul_vect(content, 'CsaImage.DiffusionGradientDirection');
         data_file.B_vect         = B_vect;
         data_file.BValue         = str2double( get_field_one     ( content, '"CsaSeries.MrPhoenixProtocol.sDiffusion.alBValue\[1\]"' ) );
         data_file.DiffDirections = str2double( get_field_one     ( content, 'CsaSeries.MrPhoenixProtocol.sDiffusion.lDiffDirections' ) );
+        if ~isempty( B_value ) && isscalar(B_value) && B_value == 0 && isempty(B_vect) %#ok<BDSCI> % only a b0, special case...
+            data_file.DiffDirections = -1;
+        end
+        
         %------------------------------------------------------------------
         % Machine
         %------------------------------------------------------------------

--- a/objects/get_sequence_param_from_json.m
+++ b/objects/get_sequence_param_from_json.m
@@ -11,7 +11,7 @@ function [ param ] = get_sequence_param_from_json( json_filename, par )
 %
 % par is a structure of parameter
 %   par.pct is a flag to activate Parallel Computing Toolbox
-%   par.read_sequence_param =1  flag to activate reading of all sequence parameter 
+%   par.read_sequence_param =1  flag to activate reading of all sequence parameter
 %
 % see also gfile gdir parpool
 %
@@ -33,7 +33,7 @@ defpar.read_sequence_param = 1;% if 1 read all sequence parameter assuming dcmst
 
 par = complet_struct(par,defpar);
 
-pct = par.pct; 
+pct = par.pct;
 
 %% Main loop
 
@@ -120,12 +120,12 @@ for j = 1 : size(json_filename,1)
         data_file.SliceTiming = SliceTiming;
         
         % bvals & bvecs
-        B_value = get_field_mul(content, 'CsaImage.B_value', 0); B_value = str2double(B_value)';
-        data_file.B_value = B_value;
-        B_vect  = get_field_mul_vect(content, 'CsaImage.DiffusionGradientDirection');
-        data_file.B_vect = B_vect;
-        data_file.BValue = str2double( get_field_one( content, '"CsaSeries.MrPhoenixProtocol.sDiffusion.alBValue\[1\]"' ) );
-        
+        B_value                  =             get_field_mul     (content, 'CsaImage.B_value', 0); B_value = str2double(B_value)';
+        data_file.B_value        = B_value;
+        B_vect                   =             get_field_mul_vect(content, 'CsaImage.DiffusionGradientDirection');
+        data_file.B_vect         = B_vect;
+        data_file.BValue         = str2double( get_field_one     ( content, '"CsaSeries.MrPhoenixProtocol.sDiffusion.alBValue\[1\]"' ) );
+        data_file.DiffDirections = str2double( get_field_one     ( content, 'CsaSeries.MrPhoenixProtocol.sDiffusion.lDiffDirections' ) );
         %------------------------------------------------------------------
         % Machine
         %------------------------------------------------------------------
@@ -138,8 +138,9 @@ for j = 1 : size(json_filename,1)
         % Subject
         %------------------------------------------------------------------
         data_file.PatientName      =clean_string(get_field_one( content, 'PatientName'      ) ) ;
-                  PatientAge       =             get_field_one( content, 'PatientAge'       )   ;
-        data_file.PatientAge       = str2double( PatientAge(1:3) )   ;
+        PatientAge       =             get_field_one( content, 'PatientAge'       )   ;
+        if ~isempty(PatientAge), PatientAge(end) = []; end% remove Y from 053Y, (this if/)
+        data_file.PatientAge       = str2double( PatientAge )   ;
         data_file.PatientBirthDate = str2double( get_field_one( content, 'PatientBirthDate' ) ) ;
         data_file.PatientWeight    = str2double( get_field_one( content, 'PatientWeight'    ) ) ;
         data_file.PatientSex       =             get_field_one( content, 'PatientSex'       )   ;
@@ -152,7 +153,11 @@ for j = 1 : size(json_filename,1)
         data_file.StudyTime       = str2double( get_field_one( content, 'StudyTime'       ) ) ;
         data_file.AcquisitionTime = min(cellfun( @str2double, get_field_mul(content, 'AcquisitionTime',0) )); % AcquisitionTime is special, it depends on 3D vs 4D
         tt=num2str(data_file.AcquisitionDate) ;
-        data_file.AcqDateStr = [tt(1:4), '_', tt(5:6), '_' tt(7:8)];
+        if ~isempty(tt) && ~strcmp(tt,'NaN')
+            data_file.AcqDateStr = [tt(1:4), '_', tt(5:6), '_' tt(7:8)];
+        else
+            data_file.AcqDateStr = '';
+        end
         
         %------------------------------------------------------------------
         % Study / Serie
@@ -224,19 +229,23 @@ for j = 1 : size(json_filename,1)
         data_file.InPlanePhaseEncodingDirection = InPlanePhaseEncodingDirection;
         PhaseEncodingDirectionPositive = get_field_one(content, 'CsaImage.PhaseEncodingDirectionPositive'); PhaseEncodingDirectionPositive = str2double(PhaseEncodingDirectionPositive);
         data_file.PhaseEncodingDirectionPositive = PhaseEncodingDirectionPositive;
-        switch InPlanePhaseEncodingDirection % InPlanePhaseEncodingDirection
-            case 'COL'
-                phase_dir = 'j';
-            case 'ROW'
-                phase_dir = 'i';
-            otherwise
-                warning('wtf ? InPlanePhaseEncodingDirection')
-                phase_dir = '';
+        if ~isempty( InPlanePhaseEncodingDirection ) % f*cking bug...
+            switch InPlanePhaseEncodingDirection % InPlanePhaseEncodingDirection
+                case 'COL'
+                    phase_dir = 'j';
+                case 'ROW'
+                    phase_dir = 'i';
+                otherwise
+                    warning('wtf ? InPlanePhaseEncodingDirection')
+                    phase_dir = '';
+            end
+            if PhaseEncodingDirectionPositive
+                phase_dir = [phase_dir '-']; %#ok<AGROW>
+            end
+            data_file.PhaseEncodingDirection = phase_dir;
+        else
+            data_file.PhaseEncodingDirection = '';
         end
-        if PhaseEncodingDirectionPositive
-            phase_dir = [phase_dir '-']; %#ok<AGROW>
-        end
-        data_file.PhaseEncodingDirection = phase_dir;
         
         data_file.PATMode     = str2double( get_field_one( content, 'CsaSeries.MrPhoenixProtocol.sPat.ucPATMode'     ) ) ;
         data_file.AccelFactPE = str2double( get_field_one( content, 'CsaSeries.MrPhoenixProtocol.sPat.lAccelFactPE'  ) ) ;
@@ -351,7 +360,7 @@ end
 token = regexp(line, ': (.*),','tokens'); % extract the value from the line
 if isempty(token)
     result = [];
-    return 
+    return
 else
     res    = token{1}{1};
     VECT_cell_raw = strsplit(res,'\n')';

--- a/objects/str2char.m
+++ b/objects/str2char.m
@@ -1,4 +1,4 @@
-function str = str2char( name, content )
+function str = str2char( content, name )
 %GEN_SERIE_NAME
 %
 % Exemple :
@@ -11,7 +11,7 @@ function str = str2char( name, content )
 % param.mxdim = [210 212 56];
 % param.numepty = [];
 %
-% gen_serie_name('dwi',param)
+% str2char(param,'dwi')
 %
 % ans =
 %     'dwi: TR=1520 TE=30 seqname=cmrr_mbep2d_bold mlchar=ffffgggg pxdim=1.7x1.7x2 mxdim=210x212x56 numepty=[]'
@@ -19,13 +19,26 @@ function str = str2char( name, content )
 
 %% Check input arguments
 
+if nargin < 1
+    help(mfilename)
+    return
+end
+
+if nargin < 2
+    name = '';
+end
+
 assert( ischar  (name   ) , 'name must be a char'      )
 assert( isstruct(content) , 'content must be a struct' )
 
 
 %% Concat name and content into a char
 
-str = [name ':'];
+if isempty(name)
+    str = '';
+else
+    str = [name ':'];
+end
 
 fields = fieldnames(content);
 
@@ -40,7 +53,7 @@ for i = 1  : length(fields)
         if nbr == 0
             str = sprintf('%s %s=[]',str,fname);
         elseif nbr == 1
-            str = sprintf('%s %s=%d',str,fname,current);
+            str = sprintf('%s %s=%g',str,fname,current);
         else
             rep      = repmat('%gx',[1 nbr]);
             rep(end) = [];
@@ -59,6 +72,10 @@ for i = 1  : length(fields)
         
     end
     
+end
+
+if isempty(name) && ~isempty(str)
+    str(1) = [];
 end
 
 

--- a/objects/str2char.m
+++ b/objects/str2char.m
@@ -1,0 +1,65 @@
+function str = str2char( name, content )
+%GEN_SERIE_NAME
+%
+% Exemple :
+%
+% param.TR = 1520;
+% param.TE = 30;
+% param.seqname = 'cmrr_mbep2d_bold';
+% param.mlchar = ['ffff';'gggg'];
+% param.pxdim = [1.7 1.7 2];
+% param.mxdim = [210 212 56];
+% param.numepty = [];
+%
+% gen_serie_name('dwi',param)
+%
+% ans =
+%     'dwi: TR=1520 TE=30 seqname=cmrr_mbep2d_bold mlchar=ffffgggg pxdim=1.7x1.7x2 mxdim=210x212x56 numepty=[]'
+%
+
+%% Check input arguments
+
+assert( ischar  (name   ) , 'name must be a char'      )
+assert( isstruct(content) , 'content must be a struct' )
+
+
+%% Concat name and content into a char
+
+str = [name ':'];
+
+fields = fieldnames(content);
+
+for i = 1  : length(fields)
+    
+    fname   = fields{i};
+    current = content.(fname);
+    sze = size (current);
+    nbr = numel(current);
+    
+    if isa(current,'double')
+        if nbr == 0
+            str = sprintf('%s %s=[]',str,fname);
+        elseif nbr == 1
+            str = sprintf('%s %s=%d',str,fname,current);
+        else
+            rep      = repmat('%gx',[1 nbr]);
+            rep(end) = [];
+            str = sprintf(['%s %s=' rep],str,fname,current);
+        end
+        
+    elseif isa(current,'char')
+        if nbr==0 % empty char
+            % pass
+        elseif sze(1) > 1 % multi ligne
+            tmp = reshape(current', [1 nbr]);
+            str = sprintf('%s %s=%s',str,fname,tmp);
+        else
+            str = sprintf('%s %s=%s',str,fname,current);
+        end
+        
+    end
+    
+end
+
+
+end % function


### PR DESCRIPTION
# job_* enhacements

@volume object can be used as input + more help :
- job_do_segment
- job_do_segmentCAT12
- job_apply_normalize
- do_topup_unwarp_4D
- job_coregister
- job_realign
- job_slice_timing
- job_smooth

Can skip if exist :
- job_first_level_specify
- job_first_level_estimate

job_do_segmentCAT12 : possibility to ask for wp* (like wc*) warped probability (compartment) maps

job_meica_afni : added the export of **t**ime**s**eries_**o**ptimaly**c**ombined volume (*tsoc_nogs.nii* ). This is important in case of crash of the TEDANA part.  

Output of do_fsl_* are columns, instead of lines :
- do_fsl_add
- do_fsl_mult

# QC / analyze series

- new @serie/seq2str
- new @exam/regroupSeries, similar to @exam/countSeries, but using @serie.sequence to make groups, depending on the list of parameters you want.
- @exam/analyzeCountSeries -> @exam/analyzeSeries
- @exam/compareOrientation : upgrade, more robust

# mvObject

- cellstr2regex : can now ask for "exactly" the expression you need -> ^expr$
- @exam/getExam can now use a cellstr as input, to ask for "exactly" (^expr$)
- new @mvObject/toStruct
- new @mvObject/unique
- new str2char

# Other

- get_sequence_param_from_json : more robust, some new fields, updated fields
- auto_import_obj : better dwi support, with better bvals bvect and INTERRUPT flag