### PR TITLE
Optimize auto_add_obj MultiEcho

### DIFF
--- a/SPM/preproc/job_afni_proc_multi_echo.m
+++ b/SPM/preproc/job_afni_proc_multi_echo.m
@@ -288,15 +288,20 @@ if obj && par.auto_add_obj && (par.run || par.sge)
     
     for iSubj = 1 : length(meinfo.data)
         for iRun = 1 : length(meinfo.data{iSubj})
+            
+            % Shortcut
+            echo = meinfo.data{iSubj}{iRun}(1); % use first echo because all echos are in the same dir
+            
+            % Fetch the good serie
+            % In case of empty element in in_obj, this "weird" strategy is very robust.
+            if par.seperate
+                serie  = meinfo.volume(iSubj,1,1).serie;
+            else
+                series = [in_obj(iSubj,:,1).serie]';
+                serie  = series.getVolume(echo.pth ,'path').removeEmpty.getOne.serie;
+            end            
+            
             for iEcho = 1 : length(meinfo.data{iSubj}{iRun})
-                
-                % Shortcut
-                echo = meinfo.data{iSubj}{iRun}(iEcho);
-                
-                % Fetch the good serie
-                % In case of empty element in in_obj, this "weird" strategy is very robust.
-                series = [in_obj.serie]';
-                serie = series.getVolume(echo.pth ,'path').removeEmpty.getOne.serie;
                 
                 if     par.run % use the normal method
                     serie.addVolume( ['^' prefix echo.outname echo.ext '$']          , sprintf('%se%d',prefix,iEcho), 1 );

--- a/SPM/preproc/job_sort_echos.m
+++ b/SPM/preproc/job_sort_echos.m
@@ -253,19 +253,21 @@ if obj && par.auto_add_obj && (par.run || par.sge)
     
     for iSubj = 1 : length(meinfo_.data)
         for iRun = 1 : length(meinfo_.data{iSubj})
+            
+            % Shortcut
+            echo = meinfo_.data{iSubj}{iRun}(1); % use first echo because all echos are in the same dir
+            
+            % Fetch the good serie
+            % In case of empty element in in_obj, this "weird" strategy is very robust.
+            serie = in_obj(iSubj,:).getVolume( echo.pth ,'path').removeEmpty.getOne.serie;
+            
             for iEcho = 1 : length(meinfo_.data{iSubj}{iRun})
                 
-                % Shortcut
-                echo = meinfo_.data{iSubj}{iRun}(iEcho);
-                
-                % Fetch the good serie
-                % In case of empty element in in_obj, this "weird" strategy is very robust.
-                serie = in_obj.getVolume( echo.pth ,'path').removeEmpty.getOne.serie;
-                
-                if par.run     % use the normal method
+                if     par.run % use the normal method
                     serie.addVolume( ['^' echo.outname echo.ext '$'] , sprintf('e%d',iEcho), 1 );
                 elseif par.sge % add the new volume in the object manually, because the file is not created yet
-                    serie.volume(end + 1) = volume( echo.fname, sprintf('e%d',iEcho), serie.exam, serie );
+                    % serie.volume(end + 1) = volume( echo.fname, sprintf('e%d',iEcho), serie.exam, serie );
+                    serie.addVolume('root', echo.fname, sprintf('e%d',iEcho))
                 end
                 
             end % iEcho
@@ -273,6 +275,7 @@ if obj && par.auto_add_obj && (par.run || par.sge)
     end % iSubj
     
     meinfo_.volume = in_obj.getVolume('^e\d+$');
+    
     
 end
 


### PR DESCRIPTION
In `job_sort_echos` and `job_afni_proc_multi_echo`, the computation time of the _auto_add_obj_ was proportional to **nSubj<sup>2</sup> x nRun<sup>2</sup> x nEcho**.
The quadratic (<sup>2</sup>) effect was negligible with small & modest size dataset. However, with large dataset (nSubj > 100 & Run > 1) the computation time was atrocious. This is due do bad code optimization, which is corrected with this PR.
New cputime is proportional to **nSubj x nRun x nEcho**. Yay !
